### PR TITLE
fix: ending a stage sets pause timeout

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -162,7 +162,7 @@ module.exports = {
 		if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
 			if (await !player) return;
 			if (await !player?.connected) return;
-			if (await !oldState.channel?.members.find(m => m.user.id === bot.user.id)) return;
+			if (await !oldState.channel.members.find(m => m.user.id === bot.user.id)) return;
 		}
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -158,6 +158,12 @@ module.exports = {
 			await player.musicHandler.disconnect();
 			return;
 		}
+		// prevent the bot set a pauset timeout when a stage ends
+		if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
+			if (await !player) return;
+			if (await !player?.connected) return;
+			if (await !oldState.channel?.members.find(m => m.user.id === bot.user.id)) return;
+		}
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
 		if (player.pauseTimeout) {

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -158,7 +158,7 @@ module.exports = {
 			await player.musicHandler.disconnect();
 			return;
 		}
-		// prevent the bot set a pauset timeout when a stage ends
+		// do not set pause timeout when a stage ends
 		if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
 			if (await !player) return;
 			if (await !player?.connected) return;

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -16,7 +16,7 @@ module.exports = {
 			// just the suppress state changed
 			if ((oldState.suppress !== newState.suppress || oldState.serverMute !== newState.serverMute || oldState.serverDeaf !== newState.serverDeaf) && oldState.channelId === newState.channelId) return;
 			// disconnected
-			if (!newState.channelId || !newState.channel?.members.find(m => m.user.id === bot.user.id)) {
+			if (!newState.channelId || !newState.channel?.members.get(bot.user.id)) {
 				logger.info({ message: `[G ${player.guildId}] Cleaning up`, label: 'Quaver' });
 				if (guildData.get(`${player.guildId}.always.enabled`)) {
 					guildData.set(`${player.guildId}.always.enabled`, false);
@@ -162,7 +162,7 @@ module.exports = {
 		if (oldState.channel.type === 'GUILD_STAGE_VOICE') {
 			if (await !player) return;
 			if (await !player?.connected) return;
-			if (await !oldState.channel.members.find(m => m.user.id === bot.user.id)) return;
+			if (await !oldState.channel.members.get(bot.user.id)) return;
 		}
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });


### PR DESCRIPTION
Fixes #155

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Did you document your code? 
> Temporary documentation only.
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Description
Please describe the changes.

I have no idea why. Not touching this code anymore. Please analyze it why, provide better approach or alternatives if so. 

Await is completely unnecessary here, but it fixes it like that so I'm not touching it anymore lol, and I need to know why it does it. This PR should not be merged like this until there is a reason why.

This is code is temporary for later references and should be changed.

Take a look at the video for testing demo.
- Playing with Quaver then ending the stage directly.
- Playing with Quaver, human leaves (testing if pause timeout works), then joins again to resume, end the stage.

https://user-images.githubusercontent.com/18362871/164371526-11b43338-a1da-480e-8209-9036ccf8d3a4.mp4

Full console log
```js
$ node .
2022-04-21T04:14:45.243Z [Discord] INFO: Connected. Logged in as Aia#3990.
2022-04-21T04:14:45.247Z [Quaver] INFO: Running version 3.4.2-next.3. For help, see h
ttps://github.com/ZapSquared/Quaver/issues.
2022-04-21T04:14:45.247Z [Quaver] WARN: You are running an unstable version of Quaver
. Please report bugs using the link above, and note that features may change or be re
moved entirely prior to release.
2022-04-21T04:14:46.200Z [Lavalink] INFO: Connected.
2022-04-21T04:14:54.117Z [Quaver] INFO: [G 906471497231630336 | U 250934589621665793]
 Processing command play
2022-04-21T04:14:54.123Z [Quaver] INFO: [G 906471497231630336 | U 250934589621665793]
 Executing command play
2022-04-21T04:14:56.921Z [Quaver] INFO: [G 906471497231630336] Starting track
2022-04-21T04:15:01.847Z [Quaver] INFO: [G 906471497231630336] Cleaning up
2022-04-21T04:15:11.882Z [Quaver] INFO: [G 906471497231630336 | U 250934589621665793]
 Processing command play
2022-04-21T04:15:11.887Z [Quaver] INFO: [G 906471497231630336 | U 250934589621665793]
 Executing command play
 // Ignore this, this is handled. Not within the scope of this pr.
2022-04-21T04:15:14.494Z [Quaver] ERROR: The Stage is already open
DiscordAPIError: The Stage is already open
    at RequestHandler.execute (C:\Users\Ava\Documents\GitHub\Quaver\node_modules\disc
ord.js\src\rest\RequestHandler.js:350:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async RequestHandler.push (C:\Users\Ava\Documents\GitHub\Quaver\node_modules\d
iscord.js\src\rest\RequestHandler.js:51:14)
    at async StageInstanceManager.create (C:\Users\Ava\Documents\GitHub\Quaver\node_m
odules\discord.js\src\managers\StageInstanceManager.js:65:18)
    at async Object.execute (C:\Users\Ava\Documents\GitHub\Quaver\events\voiceStateUp
date.js:85:7)
2022-04-21T04:15:14.840Z [Quaver] INFO: [G 906471497231630336] Starting track
2022-04-21T04:15:20.716Z [Quaver] INFO: [G 906471497231630336] Setting pause timeout
2022-04-21T04:15:35.087Z [Quaver] INFO: [G 906471497231630336] Cleaning up
```

## Testing the same steps using 3.4.2-next.3 without these changes

- Playing with Quaver then ending the stage directly.
- Playing with Quaver, human leaves (testing if pause timeout works), then joins again to resume, end the stage.

https://user-images.githubusercontent.com/18362871/164375530-fa423fb6-115c-433f-bb45-857c94697be7.mp4

Full console log
```js
$ node .
2022-04-21T04:56:12.362Z [Discord] INFO: Connected. Logged in as Aia#3990.
2022-04-21T04:56:12.366Z [Quaver] INFO: Running version 3.4.2-next.3. For help,
see https://github.com/ZapSquared/Quaver/issues.
2022-04-21T04:56:12.367Z [Quaver] WARN: You are running an unstable version of Q
uaver. Please report bugs using the link above, and note that features may chang
e or be removed entirely prior to release.
2022-04-21T04:56:13.346Z [Lavalink] INFO: Connected.
2022-04-21T04:56:20.191Z [Quaver] INFO: [G 906471497231630336 | U 25093458962166
5793] Processing command play
2022-04-21T04:56:20.195Z [Quaver] INFO: [G 906471497231630336 | U 25093458962166
5793] Executing command play
2022-04-21T04:56:24.225Z [Quaver] INFO: [G 906471497231630336] Starting track
2022-04-21T04:56:29.249Z [Quaver] INFO: [G 906471497231630336] Cleaning up
2022-04-21T04:56:29.267Z [Quaver] INFO: [G 906471497231630336] Setting pause tim
eout
2022-04-21T04:56:40.608Z [Quaver] INFO: [G 906471497231630336 | U 25093458962166
5793] Processing command play
2022-04-21T04:56:40.610Z [Quaver] INFO: [G 906471497231630336 | U 25093458962166
5793] Executing command play
2022-04-21T04:56:43.969Z [Quaver] INFO: [G 906471497231630336] Starting track
2022-04-21T04:56:50.296Z [Quaver] INFO: [G 906471497231630336] Setting pause tim
eout
2022-04-21T04:57:02.910Z [Quaver] INFO: [G 906471497231630336] Cleaning up
2022-04-21T04:57:02.915Z [Quaver] INFO: [G 906471497231630336] Setting pause tim
eout
```
