### PR TITLE
refactor: use await for remaining shuttingDown() invokers

### DIFF
--- a/main.js
+++ b/main.js
@@ -62,7 +62,7 @@ rl.on('line', async input => {
 	}
 });
 // 'close' event catches ctrl+c, therefore we pass it to shuttingDown as a ctrl+c event
-rl.on('close', () => shuttingDown('SIGINT'));
+rl.on('close', async () => await shuttingDown('SIGINT'));
 
 load({
 	client: {
@@ -184,7 +184,7 @@ for (const file of musicEventFiles) {
 bot.login(token);
 
 ['exit', 'SIGINT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].forEach(eventType => {
-	process.on(eventType, err => shuttingDown(eventType, err));
+	process.on(eventType, async err => await shuttingDown(eventType, err));
 });
 
 module.exports.startup = false;


### PR DESCRIPTION
An extension of pull request #307 that fully resolves issue #306

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

Addresses remaining invokers of `shuttingDown()` not using await.