### PR TITLE
refactor: use PlayerHandler#send on shuttingDown()

### DIFF
--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -51,6 +51,7 @@ module.exports = class PlayerHandler {
 					.setColor(error ? 'DARK_RED' : defaultColor),
 				...embedExtras?.additionalEmbeds ?? [],
 			],
+			...embedExtras?.additionalOptions ?? {},
 		};
 		if (embedExtras?.components) sendData.components = embedExtras.components;
 		return sendData;

--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -51,8 +51,8 @@ module.exports = class PlayerHandler {
 					.setColor(error ? 'DARK_RED' : defaultColor),
 				...embedExtras?.additionalEmbeds ?? [],
 			],
-			...embedExtras?.additionalOptions ?? {},
 		};
+		if (embedExtras?.files) sendData.files = embedExtras.files;
 		if (embedExtras?.components) sendData.components = embedExtras.components;
 		return sendData;
 	}

--- a/main.js
+++ b/main.js
@@ -119,7 +119,7 @@ async function shuttingDown(eventType, err) {
 				fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
 			}
 			await player.handler.disconnect();
-			await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
+			const success = await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
 				{
 					footer: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY'),
 					additionalOptions: {
@@ -132,6 +132,7 @@ async function shuttingDown(eventType, err) {
 					},
 				},
 			);
+			if (!success) continue;
 		}
 	}
 	if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {

--- a/main.js
+++ b/main.js
@@ -1,11 +1,11 @@
 require('@lavaclient/queue/register');
-const { Client, Intents, Collection, MessageEmbed } = require('discord.js');
+const { Client, Intents, Collection } = require('discord.js');
 const { Node } = require('lavaclient');
 const { load } = require('@lavaclient/spotify');
 const fs = require('fs');
 const fsPromises = require('fs').promises;
 const readline = require('readline');
-const { token, lavalink, spotify, defaultColor, defaultLocale, functions } = require('./settings.json');
+const { token, lavalink, spotify, defaultLocale, functions } = require('./settings.json');
 const { msToTime, msToTimeString, getLocale } = require('./functions.js');
 const { logger, data } = require('./shared.js');
 
@@ -119,22 +119,19 @@ async function shuttingDown(eventType, err) {
 				fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
 			}
 			await player.handler.disconnect();
-			const botChannelPerms = bot.guilds.cache.get(player.guildId).channels.cache.get(player.queue.channel.id).permissionsFor(bot.user.id);
-			if (!botChannelPerms.has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) { continue; }
-			await player.queue.channel.send({
-				embeds: [
-					new MessageEmbed()
-						.setDescription(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`)
-						.setFooter({ text: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY') })
-						.setColor(defaultColor),
-				],
-				files: fileBuffer.length > 0 ? [
-					{
-						attachment: Buffer.from(fileBuffer.join('\n')),
-						name: 'queue.txt',
+			await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
+				{
+					footer: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY'),
+					additionalOptions: {
+						files: fileBuffer.length > 0 ? [
+							{
+								attachment: Buffer.from(fileBuffer.join('\n')),
+								name: 'queue.txt',
+							},
+						] : [],
 					},
-				] : [],
-			});
+				},
+			);
 		}
 	}
 	if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {

--- a/main.js
+++ b/main.js
@@ -122,14 +122,12 @@ async function shuttingDown(eventType, err) {
 			const success = await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
 				{
 					footer: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY'),
-					additionalOptions: {
-						files: fileBuffer.length > 0 ? [
-							{
-								attachment: Buffer.from(fileBuffer.join('\n')),
-								name: 'queue.txt',
-							},
-						] : [],
-					},
+					files: fileBuffer.length > 0 ? [
+						{
+							attachment: Buffer.from(fileBuffer.join('\n')),
+							name: 'queue.txt',
+						},
+					] : [],
 				},
 			);
 			if (!success) continue;


### PR DESCRIPTION
Closes #236

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

When shuttingDown, will use PlayerHandler's send method instead.