### PR TITLE
fix: use return instead of break

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -89,10 +89,10 @@ module.exports = {
 				}
 				case 'NO_MATCHES':
 					await interaction.replyHandler.localeError('CMD_PLAY_NO_RESULTS');
-					break;
+					return;
 				case 'LOAD_FAILED':
 					await interaction.replyHandler.localeError('CMD_PLAY_LOAD_FAILED');
-					break;
+					return;
 				default:
 					await interaction.replyHandler.localeError('DISCORD_CMD_ERROR');
 					return;


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
On loadTypes `NO_MATCHES` and `LOAD_FAILED` should return to not proceed the queueing process any further. This affects functionality otherwise.
Fixes #320.