### PR TITLE
fix: trigger pause timeout when there are no humans

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -152,8 +152,6 @@ module.exports = {
 		if (newState.channelId === oldState.channelId) return;
 		// vc still has people
 		if (oldState.channel.members.filter(m => !m.user.bot).size >= 1) return;
-		// player's gone!
-		if (!player.connected) return;
 		// 24/7 mode enabled, ignore
 		if (await data.guild.get(guild.id, 'settings.stay.enabled')) return;
 		// nothing is playing so we just leave


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Fixes #174
Removes a statement preventing Quaver from setting pause timeout when a user immediately leaves from a voice or stage channel after queueing a track.