### PR TITLE
fix(voiceStateUpdate): set pause timeout when moved to stage

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -74,7 +74,6 @@ module.exports = {
 				if (await data.guild.get(player.guildId, 'settings.stay.enabled') && await data.guild.get(player.guildId, 'settings.stay.channel') !== newState.channelId) {
 					await data.guild.set(player.guildId, 'settings.stay.channel', newState.channelId);
 				}
-				return;
 			}
 			// the new vc has no humans
 			if (newState.channel.members.filter(m => !m.user.bot).size < 1 && !await data.guild.get(player.guildId, 'settings.stay.enabled')) {


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.

When moved to a stage channel with no humans, Quaver should set pause timeout when there is a track playing. Otherwise, disconnect from being alone.

Fixes #343

**Testing**
> What I did in the video
1. Start Quaver
2. User joins a voice channel
3. User plays any track
4. User moves Quaver to a stage channel
5. User moves to the stage channel as well to resume session
6. User skips the current playing track
7. User moves Quaver to a voice channel for it to leave due to being alone while nothing is playing.

> After that, I did the shorter alternative
1. User moves to a voice channel
2. User plays any track in the voice channel
3. User skips the current playing track
4. User moves Quaver from the voice channel to a stage channel for it to leave due to being alone while nothing is playing.

https://user-images.githubusercontent.com/18362871/179210074-c17c0e46-4005-4ea2-8d2a-1bb00b17be1c.mp4


