### PR TITLE
refactor: add missing await to PlayerHandler method invokes

### DIFF
--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -4,10 +4,10 @@ module.exports = {
 	name: 'guildDelete',
 	once: false,
 	/** @param {import('discord.js').Guild} guild */
-	execute(guild) {
+	async execute(guild) {
 		const { bot } = require('../main.js');
 		logger.info({ message: `[G ${guild.id}] Left guild ${guild.name}`, label: 'Discord' });
 		const player = bot.music.players.get(guild.id);
-		if (player) player.handler.disconnect();
+		if (player) await player.handler.disconnect();
 	},
 };

--- a/events/music/queueFinish.js
+++ b/events/music/queueFinish.js
@@ -8,7 +8,7 @@ module.exports = {
 	/** @param {import('@lavaclient/queue').Queue & {player: import('lavaclient').Player & {handler: import('../../classes/PlayerHandler.js')}}} queue */
 	async execute(queue) {
 		if (await data.guild.get(queue.player.guildId, 'settings.stay.enabled')) {
-			queue.player.handler.locale('MUSIC_QUEUE_EMPTY');
+			await queue.player.handler.locale('MUSIC_QUEUE_EMPTY');
 			return;
 		}
 		// rare case where the bot sets timeout after setting pause timeout
@@ -22,6 +22,6 @@ module.exports = {
 			p.handler.locale('MUSIC_INACTIVITY');
 			p.handler.disconnect();
 		}, 1800000, queue.player);
-		queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`);
+		await queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`);
 	},
 };

--- a/events/music/trackEnd.js
+++ b/events/music/trackEnd.js
@@ -13,11 +13,11 @@ module.exports = {
 		delete queue.player.skip;
 		if (reason === 'LOAD_FAILED') {
 			logger.warn({ message: `[G ${queue.player.guildId}] Track skipped with reason: ${reason}`, label: 'Quaver' });
-			queue.player.handler.locale('MUSIC_TRACK_SKIPPED', {}, true, track.title, track.uri, reason);
+			await queue.player.handler.locale('MUSIC_TRACK_SKIPPED', {}, true, track.title, track.uri, reason);
 		}
 		if (bot.guilds.cache.get(queue.player.guildId).channels.cache.get(queue.player.channelId).members?.filter(m => !m.user.bot).size < 1 && !await data.guild.get(queue.player.guildId, 'settings.stay.enabled')) {
 			logger.info({ message: `[G ${queue.player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
-			queue.player.handler.locale('MUSIC_ALONE');
+			await queue.player.handler.locale('MUSIC_ALONE');
 			await queue.player.handler.disconnect();
 			return;
 		}

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -134,7 +134,7 @@ module.exports = {
 		// nothing is playing so we just leave
 		if (!player.queue.current || !player.playing && !player.paused) {
 			logger.info({ message: `[G ${player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
-			player.handler.locale('MUSIC_ALONE');
+			await player.handler.locale('MUSIC_ALONE');
 			await player.handler.disconnect();
 			return;
 		}


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Closes #347

Only adds await to PlayerHandler method invokers that needs it. Invokers that were in `setTimeout` function were excluded from the change.