### PR TITLE
fix: do not set a "new pause timeout" if it exists

### DIFF
--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -108,6 +108,7 @@ module.exports = {
 			}
 			// Moved to a new channel that has humans and pauseTimeout is set
 			else if (newState.channel.members.filter(m => !m.user.bot).size >= 1 && player.pauseTimeout) {
+				logger.info({ message: `[G ${player.guildId}] Resuming (alone)`, label: 'Quaver' });
 				player.resume();
 				clearTimeout(player.pauseTimeout);
 				delete player.pauseTimeout;
@@ -121,6 +122,7 @@ module.exports = {
 		/** Checks for when a user joins or moves */
 		// User joined or moved to Quaver's channel, and pauseTimeout is set
 		if (newState.channelId === player?.channelId && player?.pauseTimeout) {
+			logger.info({ message: `[G ${player.guildId}] Resuming (alone)`, label: 'Quaver' });
 			player.resume();
 			if (player.pauseTimeout) {
 				clearTimeout(player.pauseTimeout);

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -108,7 +108,7 @@ module.exports = {
 			}
 			// Moved to a new channel that has humans and pauseTimeout is set
 			else if (newState.channel.members.filter(m => !m.user.bot).size >= 1 && player.pauseTimeout) {
-				logger.info({ message: `[G ${player.guildId}] Resuming (alone)`, label: 'Quaver' });
+				logger.info({ message: `[G ${player.guildId}] Resuming session`, label: 'Quaver' });
 				player.resume();
 				clearTimeout(player.pauseTimeout);
 				delete player.pauseTimeout;
@@ -122,7 +122,7 @@ module.exports = {
 		/** Checks for when a user joins or moves */
 		// User joined or moved to Quaver's channel, and pauseTimeout is set
 		if (newState.channelId === player?.channelId && player?.pauseTimeout) {
-			logger.info({ message: `[G ${player.guildId}] Resuming (alone)`, label: 'Quaver' });
+			logger.info({ message: `[G ${player.guildId}] Resuming session`, label: 'Quaver' });
 			player.resume();
 			if (player.pauseTimeout) {
 				clearTimeout(player.pauseTimeout);

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -95,9 +95,8 @@ module.exports = {
 				// Quaver was playing something - set pauseTimeout
 				await player.pause();
 				logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-				if (player.pauseTimeout) {
-					clearTimeout(player.pauseTimeout);
-				}
+				// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
+				if (player.pauseTimeout) return;
 				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 					p.handler.locale('MUSIC_INACTIVITY');
@@ -152,9 +151,8 @@ module.exports = {
 		// Quaver was playing something - set pauseTimeout
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-		if (player.pauseTimeout) {
-			clearTimeout(player.pauseTimeout);
-		}
+		// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
+		if (player.pauseTimeout) return;
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.handler.locale('MUSIC_INACTIVITY');

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -97,7 +97,7 @@ module.exports = {
 				// Quaver was playing something - set pauseTimeout
 				await player.pause();
 				logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-				// When setting a pauseTimeout, clear pauseTimeout at any cost as failsafe
+				// Before setting a new pauseTimeout, clear the pauseTimeout first at any cost as failsafe
 				clearTimeout(player.pauseTimeout);
 				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
@@ -155,7 +155,7 @@ module.exports = {
 		// Quaver was playing something - set pauseTimeout
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-		// When setting a pauseTimeout, clear pauseTimeout at any cost as failsafe
+		// Before setting a new pauseTimeout, clear the pauseTimeout first at any cost as failsafe
 		clearTimeout(player.pauseTimeout);
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -97,6 +97,8 @@ module.exports = {
 				logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
 				// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
 				if (player.pauseTimeout) return;
+				// When setting a pauseTimeout, clear pauseTimeout at any cost as failsafe
+				clearTimeout(player.pauseTimeout);
 				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 					p.handler.locale('MUSIC_INACTIVITY');

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -151,8 +151,8 @@ module.exports = {
 		// Quaver was playing something - set pauseTimeout
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-		// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
-		if (player.pauseTimeout) return;
+		// Clear any existing pauseTimeout as failsafe before setting a new one
+		clearTimeout(player.pauseTimeout);
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
 			p.handler.locale('MUSIC_INACTIVITY');

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -92,11 +92,11 @@ module.exports = {
 				}
 				// Avoid pauseTimeout if 24/7 is enabled
 				if (await data.guild.get(player.guildId, 'settings.stay.enabled')) return;
+				// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
+				if (player.pauseTimeout) return;
 				// Quaver was playing something - set pauseTimeout
 				await player.pause();
 				logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-				// Ensure that the bot does not set a new pauseTimeout if pauseTimeout already exists
-				if (player.pauseTimeout) return;
 				// When setting a pauseTimeout, clear pauseTimeout at any cost as failsafe
 				clearTimeout(player.pauseTimeout);
 				player.pauseTimeout = setTimeout(p => {

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -151,7 +151,7 @@ module.exports = {
 		// Quaver was playing something - set pauseTimeout
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-		// Clear any existing pauseTimeout as failsafe before setting a new one
+		// When setting a pauseTimeout, clear pauseTimeout at any cost as failsafe
 		clearTimeout(player.pauseTimeout);
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -97,7 +97,7 @@ module.exports = {
 				// Quaver was playing something - set pauseTimeout
 				await player.pause();
 				logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-				// Before setting a new pauseTimeout, clear the pauseTimeout first at any cost as failsafe
+				// Before setting a new pauseTimeout, clear the pauseTimeout first as a failsafe
 				clearTimeout(player.pauseTimeout);
 				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
@@ -155,7 +155,7 @@ module.exports = {
 		// Quaver was playing something - set pauseTimeout
 		await player.pause();
 		logger.info({ message: `[G ${player.guildId}] Setting pause timeout`, label: 'Quaver' });
-		// Before setting a new pauseTimeout, clear the pauseTimeout first at any cost as failsafe
+		// Before setting a new pauseTimeout, clear the pauseTimeout first as a failsafe
 		clearTimeout(player.pauseTimeout);
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Affects functionality
Fixes #350

Should not clear and set a new pauseTimeout if it already exists.
When setting a new pauseTimeout, clear any pauseTimeout at any cost even if it can be `undefined` at `/** Checks for when a user leaves */`