### PR TITLE
refactor: use lavaclient's Player#position instead

### DIFF
--- a/commands/playing.js
+++ b/commands/playing.js
@@ -22,8 +22,8 @@ module.exports = {
 			await interaction.replyHandler.localeError('MUSIC_QUEUE_NOT_PLAYING');
 			return;
 		}
-		const bar = getBar((player.accuratePosition / player.queue.current.length) * 100);
-		let elapsed = msToTime(player.accuratePosition);
+		const bar = getBar((player.position / player.queue.current.length) * 100);
+		let elapsed = msToTime(player.position);
 		if (isNaN(elapsed['s']) || elapsed['s'] < 0) {
 			elapsed = { d: 0, h: 0, m: 0, s: 0 };
 		}


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Closes #366
Update deprecated code from usage of a deprecated property from lavaclient dependency.