### PR TITLE
fix(PlayerHandler#send): catch undefined text channels

### DIFF
--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -76,7 +76,7 @@ module.exports = class PlayerHandler {
 		const sendData = this.sendDataConstructor(msg, embedExtras, error);
 		/** @type {import('discord.js').TextChannel} */
 		const channel = this.player.queue.channel;
-		if (!channel.permissionsFor(this.client.user.id).has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) return false;
+		if (!channel?.permissionsFor(this.client.user.id)?.has(['VIEW_CHANNEL', 'SEND_MESSAGES'])) return false;
 		if (this.client.guilds.cache.get(this.player.guildId).members.cache.get(this.client.user.id).isCommunicationDisabled()) return false;
 		try {
 			return await channel.send(sendData);


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.

Fixes #371

Prevents `TypeErrors` caused by Kicking or Banning Quaver out of guilds.

Adds optional chaining operators for the checks to return false when attempting to check undefined text channels.