### PR TITLE
fix(guildDelete): remove redundant invocation of PlayerHander#disconnect

### DIFF
--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -26,7 +26,7 @@ module.exports = class PlayerHandler {
 		this.client.music.destroyPlayer(this.player.guildId);
 		const voiceChannel = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(channelId ?? this.player.channelId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
-			const permissions = this.client.guilds.cache.get(this.player.guildId).channels.cache.get(channelId ?? this.player.channelId).permissionsFor(this.client.user.id);
+			const permissions = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(channelId ?? this.player.channelId).permissionsFor(this.client.user.id);
 			if (!permissions?.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) return;
 			if (!permissions?.has(Permissions.STAGE_MODERATOR)) return;
 			if (voiceChannel.stageInstance?.topic === getLocale(await data.guild.get(this.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {

--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -27,8 +27,8 @@ module.exports = class PlayerHandler {
 		const voiceChannel = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(channelId ?? this.player.channelId);
 		if (voiceChannel?.type === 'GUILD_STAGE_VOICE') {
 			const permissions = this.client.guilds.cache.get(this.player.guildId).channels.cache.get(channelId ?? this.player.channelId).permissionsFor(this.client.user.id);
-			if (!permissions.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) return;
-			if (!permissions.has(Permissions.STAGE_MODERATOR)) return;
+			if (!permissions?.has(['VIEW_CHANNEL', 'CONNECT', 'SPEAK'])) return;
+			if (!permissions?.has(Permissions.STAGE_MODERATOR)) return;
 			if (voiceChannel.stageInstance?.topic === getLocale(await data.guild.get(this.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
 				try {
 					await voiceChannel.stageInstance.delete();

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -5,9 +5,6 @@ module.exports = {
 	once: false,
 	/** @param {import('discord.js').Guild} guild */
 	async execute(guild) {
-		const { bot } = require('../main.js');
 		logger.info({ message: `[G ${guild.id}] Left guild ${guild.name}`, label: 'Discord' });
-		const player = bot.music.players.get(guild.id);
-		if (player) await player.handler.disconnect();
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Fixes #373

Let `voiceStateUpdate` do the job alone instead of invoking `PlayerHandler#disconnect()` again from `guildDelete` where it is no longer supposed to when the bot already left the guild.