### PR TITLE
fix: let voiceStateUpdate unsuppress instead

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -120,9 +120,5 @@ module.exports = {
 		const started = player.playing || player.paused;
 		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }, ...extras);
 		if (!started) { await player.queue.start(); }
-		const state = interaction.guild.members.me.voice;
-		if (interaction.member.voice.channel.type === ChannelType.GuildStageVoice && state.suppress) {
-			await state.setSuppressed(false);
-		}
 	},
 };

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -75,9 +75,5 @@ module.exports = {
 		const started = player.playing || player.paused;
 		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null, components: [] }, ...extras);
 		if (!started) { await player.queue.start(); }
-		const state = interaction.guild.members.me.voice;
-		if (state.channel.type === ChannelType.GuildStageVoice && state.suppress) {
-			await state.setSuppressed(false);
-		}
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.

Instead of having `commands/play.js` or `components/selects/play.js` unsuppress Quaver and having to type check them, why not removing them and let `voiceStateUpdate` do the job alone of unsuppressing Quaver.