### PR TITLE
fix: destroy the player if timed out while queuing tracks

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -108,8 +108,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut) {
-				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT');
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+				timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/commands/play.js
+++ b/commands/play.js
@@ -107,8 +107,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
-				// Only send the message if Quaver is not timed out by the user
-				if (!interaction.guild?.members.me.isCommunicationDisabled()) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/commands/play.js
+++ b/commands/play.js
@@ -106,8 +106,10 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
+			if (!interaction.member.voice.channelId || timedOut) {
+				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT');
+				if (!timedOut) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/commands/play.js
+++ b/commands/play.js
@@ -106,7 +106,7 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
+			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;

--- a/commands/play.js
+++ b/commands/play.js
@@ -105,7 +105,7 @@ module.exports = {
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets timed out while queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();

--- a/commands/play.js
+++ b/commands/play.js
@@ -109,7 +109,7 @@ module.exports = {
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut) {
 				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT');
-				if (!timedOut) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/commands/play.js
+++ b/commands/play.js
@@ -107,7 +107,8 @@ module.exports = {
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+				// Only send the message if Quaver is not timed out by the user
+				if (!interaction.guild?.members.me.isCommunicationDisabled()) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/commands/play.js
+++ b/commands/play.js
@@ -104,8 +104,9 @@ module.exports = {
 			player.handler = new PlayerHandler(interaction.client, player);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
-			// that kid left while we were busy bruh
-			if (!interaction.member.voice.channelId) {
+			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out while queueing tracks
+			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -60,8 +60,9 @@ module.exports = {
 			player.handler = new PlayerHandler(interaction.client, player);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
-			// that kid left while we were busy bruh
-			if (!interaction.member.voice.channelId) {
+			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out while queueing tracks
+			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
 				await player.handler.disconnect();
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				return;

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -65,7 +65,7 @@ module.exports = {
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut) {
 				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] });
-				if (!timedOut) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -64,7 +64,8 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
 				await player.handler.disconnect();
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				// Only send the message if Quaver is not timed out by the user
+				if (!interaction.guild?.members.me.isCommunicationDisabled()) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				return;
 			}
 		}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -62,8 +62,10 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
+			if (!interaction.member.voice.channelId || timedOut) {
+				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] });
+				if (!timedOut) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -61,7 +61,7 @@ module.exports = {
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets timed out while queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
 				await player.handler.disconnect();
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -64,8 +64,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
 				await player.handler.disconnect();
-				// Only send the message if Quaver is not timed out by the user
-				if (!interaction.guild?.members.me.isCommunicationDisabled()) await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				return;
 			}
 		}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -64,8 +64,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut) {
-				if (timedOut) await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] });
-				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] }) : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -62,7 +62,7 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			if (!interaction.member.voice.channelId || interaction.guild.members.me.isCommunicationDisabled()) {
+			if (!interaction.member.voice.channelId || interaction.guild?.members.me.isCommunicationDisabled()) {
 				await player.handler.disconnect();
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				return;


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Fixes #385

Adds a check for when Quaver gets timed out while it is queueing tracks.
Updated the documentation accordingly.

Adds optional chaining operators for when `members` becomes `null` 

It is in one line together with the `// that kid left while we were busy` condition.