### PR TITLE
refactor(select-play): send the locale before invoking PlayerHandler#disconnect

### DIFF
--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -62,8 +62,8 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// that kid left while we were busy bruh
 			if (!interaction.member.voice.channelId) {
-				await player.handler.disconnect();
 				await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				await player.handler.disconnect();
 				return;
 			}
 		}


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

For consistency. In other files, the locale gets sent before `PlayerHandler#disconnect` is invoked.