### PR TITLE
fix: check for guild before queuing tracks

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -104,9 +104,9 @@ module.exports = {
 			player.handler = new PlayerHandler(interaction.client, player);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
-			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queuing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queuing tracks
+			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
 				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);

--- a/commands/play.js
+++ b/commands/play.js
@@ -106,9 +106,10 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queueing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
-			if (!interaction.member.voice.channelId || timedOut) {
-				timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
+				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -60,9 +60,9 @@ module.exports = {
 			player.handler = new PlayerHandler(interaction.client, player);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
-			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
-			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queuing tracks
+			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queuing tracks
+			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
 				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] }) : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -62,9 +62,10 @@ module.exports = {
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
 			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queueing tracks
 			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queueing tracks
+			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queueing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
-			if (!interaction.member.voice.channelId || timedOut) {
-				timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] }) : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
+				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] }) : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Fixes #392

Destroy the player if kicked or banned while queuing tracks, sends the locales only if there is a guild.