### PR TITLE
fix(PlayerHandler#disconnect): do not end stage if timed out

### DIFF
--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -29,6 +29,7 @@ module.exports = class PlayerHandler {
 			const permissions = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(channelId ?? this.player.channelId).permissionsFor(this.client.user.id);
 			if (!permissions?.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) return;
 			if (!permissions?.has(PermissionsBitField.StageModerator)) return;
+			if (this.client.guilds.cache.get(this.player.guildId)?.members.me.isCommunicationDisabled()) return false;
 			if (voiceChannel.stageInstance?.topic === getLocale(await data.guild.get(this.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
 				try {
 					await voiceChannel.stageInstance.delete();

--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -29,7 +29,7 @@ module.exports = class PlayerHandler {
 			const permissions = this.client.guilds.cache.get(this.player.guildId)?.channels.cache.get(channelId ?? this.player.channelId).permissionsFor(this.client.user.id);
 			if (!permissions?.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) return;
 			if (!permissions?.has(PermissionsBitField.StageModerator)) return;
-			if (this.client.guilds.cache.get(this.player.guildId)?.members.me.isCommunicationDisabled()) return false;
+			if (this.client.guilds.cache.get(this.player.guildId)?.members.me.isCommunicationDisabled()) return;
 			if (voiceChannel.stageInstance?.topic === getLocale(await data.guild.get(this.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_STAGE_TOPIC')) {
 				try {
 					await voiceChannel.stageInstance.delete();


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Fixes #391
A timed out user or bot will not be able to end stage instances.
There should be a check here, conditioning that if timed out, do not attempt to delete it, otherwise a DiscordApiError: Missing permissions would occur.