### PR TITLE
refactor: add failsafe to prevent reconnecting if guild is missing

### DIFF
--- a/events/music/connect.js
+++ b/events/music/connect.js
@@ -11,6 +11,7 @@ module.exports = {
 		for await (const [guildId, guildData] of data.guild.instance.iterator()) {
 			if (_.get(guildData, 'settings.stay.enabled')) {
 				const guild = bot.guilds.cache.get(guildId);
+				if (!guild) continue;
 				const player = bot.music.createPlayer(guildId);
 				player.handler = new PlayerHandler(bot, player);
 				player.queue.channel = guild.channels.cache.get(_.get(guildData, 'settings.stay.text'));


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Closes #395
Adds a failsafe for when reconnecting to a voice channel while the bot is not inside that guild.