### PR TITLE
feat: defaultColor variants

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,12 @@ The file structure is as follows:
 {
   "token": "Paste token here",
   "applicationId": "Paste application ID here",
-  "defaultColor": "#f39bff",
+  "colors": {
+    "success": "DarkGreen",
+    "neutral": "#f39bff",
+    "warning": "DarkOrange",
+    "error": "DarkRed"
+  },
   "defaultLocale": "en",
   "managers": [
     "Paste your user ID here"
@@ -41,8 +46,17 @@ The file structure is as follows:
 `applicationId`
 > The Discord application ID for your bot. Usually the same as your bot's user ID. You can also get this from [here](https://discord.com/developers/applications).
 
-`defaultColor`
-> A [`ColorResolvable`](https://discord.js.org/#/docs/main/stable/typedef/ColorResolvable) color. Used in every non-error message embed from Quaver.
+`colors.success`
+> A [`ColorResolvable`](https://discord.js.org/#/docs/discord.js/main/typedef/ColorResolvable) color. Used in every success message embed from Quaver.
+
+`colors.neutral`
+> A [`ColorResolvable`](https://discord.js.org/#/docs/discord.js/main/typedef/ColorResolvable) color. Used in every neutral message embed from Quaver.
+
+`colors.warning`
+> A [`ColorResolvable`](https://discord.js.org/#/docs/discord.js/main/typedef/ColorResolvable) color. Used in every warning message embed from Quaver.
+
+`colors.error`
+> A [`ColorResolvable`](https://discord.js.org/#/docs/discord.js/main/typedef/ColorResolvable) color. Used in every error message embed from Quaver.
 
 `defaultLocale`
 > Any locale from [locales](locales) without the file extension. Quaver will not start if an invalid locale is selected.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -9,7 +9,7 @@ The file structure is as follows:
   "colors": {
     "success": "DarkGreen",
     "neutral": "#f39bff",
-    "warning": "DarkOrange",
+    "warning": "Orange",
     "error": "DarkRed"
   },
   "defaultLocale": "en",

--- a/classes/PlayerHandler.js
+++ b/classes/PlayerHandler.js
@@ -70,10 +70,10 @@ module.exports = class PlayerHandler {
 	 * Sends a message to the bound text channel.
 	 * @param {string} msg The message to be used.
 	 * @param {{title?: string, footer?: string, thumbnail?: string, additionalEmbeds?: EmbedBuilder[], files?: import('discord.js').FileOptions[], components?: import('discord.js').ActionRowBuilder[]}} [embedExtras] Extra data to be passed to the embed.
-	 * @param {"success"|"neutral"|"warning"|"error"} [type=neutral] Type of the message. Defaults to success.
+	 * @param {"success"|"neutral"|"warning"|"error"} [type=neutral] Type of the message.
 	 * @returns {Promise<import('discord.js').Message>|Promise<import('discord-api-types/v10').APIMessage>|boolean} The message that was sent.
 	 */
-	async send(msg, embedExtras, type) {
+	async send(msg, embedExtras, type = 'neutral') {
 		const sendData = this.sendDataConstructor(msg, embedExtras, type);
 		/** @type {import('discord.js').TextChannel} */
 		const channel = this.player.queue.channel;
@@ -92,11 +92,11 @@ module.exports = class PlayerHandler {
 	 * Sends a localized message to the bound text channel.
 	 * @param {string} code The code of the locale string to be used.
 	 * @param {{title?: string, footer?: string, thumbnail?: string, additionalEmbeds?: EmbedBuilder[], files?: import('discord.js').FileOptions[], components?: import('discord.js').ActionRowBuilder[]}} [embedExtras] Extra data to be passed to the embed.
-	 * @param {"success"|"neutral"|"warning"|"error"} [type=neutral] Type of the message. Defaults to success.
+	 * @param {"success"|"neutral"|"warning"|"error"} [type=neutral] Type of the message.
 	 * @param  {...string} [args] Additional arguments to be passed to the locale string.
 	 * @returns {Promise<import('discord.js').Message>|Promise<import('discord-api-types/v10').APIMessage>|boolean} The message that was sent.
 	 */
-	async locale(code, embedExtras, type, ...args) {
+	async locale(code, embedExtras, type = 'neutral', ...args) {
 		const localizedString = getLocale(await data.guild.get(this.player.guildId, 'settings.locale') ?? defaultLocale, code, ...args);
 		return this.send(localizedString, embedExtras, type);
 	}

--- a/commands/247.js
+++ b/commands/247.js
@@ -20,16 +20,16 @@ module.exports = {
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client & {music: import('lavaclient').Node}, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (!features.stay.enabled) {
-			await interaction.replyHandler.localeError('FEATURE_DISABLED');
+			await interaction.replyHandler.locale('FEATURE_DISABLED', {}, 'error');
 			return;
 		}
 		if (features.stay.whitelist && !await data.guild.get(interaction.guildId, 'features.stay.whitelisted')) {
-			await interaction.replyHandler.localeError('CMD_247_NOT_WHITELISTED');
+			await interaction.replyHandler.locale('CMD_247_NOT_WHITELISTED', {}, 'error');
 			return;
 		}
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (!player?.queue?.channel?.id) {
-			await interaction.replyHandler.localeError('CMD_247_MISSING_CHANNEL');
+			await interaction.replyHandler.locale('CMD_247_MISSING_CHANNEL', {}, 'error');
 			return;
 		}
 		const enabled = interaction.options.getBoolean('enabled');

--- a/commands/bind.js
+++ b/commands/bind.js
@@ -24,13 +24,13 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		const channel = interaction.options.getChannel('new_channel');
 		if (!channel.permissionsFor(interaction.client.user.id).has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.SendMessages]))) {
-			await interaction.replyHandler.localeError('CMD_BIND_NO_PERMISSIONS', {}, channel.id);
+			await interaction.replyHandler.locale('CMD_BIND_NO_PERMISSIONS', {}, 'error', channel.id);
 			return;
 		}
 		player.queue.channel = channel;
 		if (await data.guild.get(interaction.guildId, 'settings.stay.enabled')) {
 			await data.guild.set(interaction.guildId, 'settings.stay.text', channel.id);
 		}
-		await interaction.replyHandler.locale('CMD_BIND_SUCCESS', {}, channel.id);
+		await interaction.replyHandler.locale('CMD_BIND_SUCCESS', {}, 'success', channel.id);
 	},
 };

--- a/commands/clear.js
+++ b/commands/clear.js
@@ -16,10 +16,10 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (player.queue.tracks.length === 0) {
-			await interaction.replyHandler.localeError('CMD_CLEAR_EMPTY');
+			await interaction.replyHandler.locale('CMD_CLEAR_EMPTY', {}, 'error');
 			return;
 		}
 		player.queue.clear();
-		await interaction.replyHandler.locale('CMD_CLEAR_SUCCESS');
+		await interaction.replyHandler.locale('CMD_CLEAR_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/disconnect.js
+++ b/commands/disconnect.js
@@ -16,11 +16,11 @@ module.exports = {
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client & {music: import('lavaclient').Node}, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (await data.guild.get(interaction.guildId, 'settings.stay.enabled')) {
-			await interaction.replyHandler.localeError('CMD_DISCONNECT_247_ENABLED');
+			await interaction.replyHandler.locale('CMD_DISCONNECT_247_ENABLED', {}, 'error');
 			return;
 		}
 		const player = interaction.client.music.players.get(interaction.guildId);
 		await player.handler.disconnect();
-		await interaction.replyHandler.locale('CMD_DISCONNECT_SUCCESS');
+		await interaction.replyHandler.locale('CMD_DISCONNECT_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/info.js
+++ b/commands/info.js
@@ -14,6 +14,6 @@ module.exports = {
 	},
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
-		await interaction.replyHandler.locale('CMD_INFO_DETAIL', { title: 'Quaver', thumbnail: interaction.client.user.avatarURL({ format: 'png' }) }, interaction.client.generateInvite({ permissions: [PermissionsBitField.Flags.Administrator], scopes: ['bot', 'applications.commands'] }), version);
+		await interaction.replyHandler.locale('CMD_INFO_DETAIL', { title: 'Quaver', thumbnail: interaction.client.user.avatarURL({ format: 'png' }) }, 'neutral', interaction.client.generateInvite({ permissions: [PermissionsBitField.Flags.Administrator], scopes: ['bot', 'applications.commands'] }), version);
 	},
 };

--- a/commands/locale.js
+++ b/commands/locale.js
@@ -1,6 +1,6 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionsBitField, Colors } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, PermissionsBitField } = require('discord.js');
 const { checks } = require('../enums.js');
-const { defaultLocale } = require('../settings.json');
+const { defaultLocale, colors } = require('../settings.json');
 const { roundTo, getLocale, checkLocaleCompletion } = require('../functions.js');
 const { data } = require('../shared.js');
 const fs = require('fs');
@@ -27,15 +27,15 @@ module.exports = {
 		const locale = interaction.options.getString('new_locale');
 		const localeCompletion = checkLocaleCompletion(locale);
 		if (localeCompletion === 'LOCALE_MISSING') {
-			await interaction.replyHandler.error('That locale does not exist.');
+			await interaction.replyHandler.reply('That locale does not exist.', {}, 'error');
 			return;
 		}
 		await data.guild.set(interaction.guildId, 'settings.locale', locale);
 		const additionalEmbed = localeCompletion.completion !== 100 ? [
 			new EmbedBuilder()
 				.setDescription(`This locale is incomplete. Completion: \`${roundTo(localeCompletion.completion, 2)}%\`\nMissing strings:\n\`\`\`\n${localeCompletion.missing.join('\n')}\`\`\``)
-				.setColor(Colors.DarkRed),
+				.setColor(colors.warning),
 		] : [];
-		await interaction.replyHandler.locale('CMD_LOCALE_SUCCESS', { additionalEmbeds: additionalEmbed }, interaction.guild.name, locale);
+		await interaction.replyHandler.locale('CMD_LOCALE_SUCCESS', { additionalEmbeds: additionalEmbed }, 'success', interaction.guild.name, locale);
 	},
 };

--- a/commands/loop.js
+++ b/commands/loop.js
@@ -45,6 +45,6 @@ module.exports = {
 		}
 		typeLocale = typeLocale.toLowerCase();
 		player.queue.setLoop(loop);
-		await interaction.replyHandler.locale('CMD_LOOP_SUCCESS', {}, typeLocale);
+		await interaction.replyHandler.locale('CMD_LOOP_SUCCESS', {}, 'neutral', typeLocale);
 	},
 };

--- a/commands/move.js
+++ b/commands/move.js
@@ -30,19 +30,19 @@ module.exports = {
 		const oldPosition = interaction.options.getInteger('old_position');
 		const newPosition = interaction.options.getInteger('new_position');
 		if (player.queue.tracks.length <= 1) {
-			await interaction.replyHandler.localeError('CMD_MOVE_INSUFFICIENT');
+			await interaction.replyHandler.locale('CMD_MOVE_INSUFFICIENT', {}, 'error');
 			return;
 		}
 		if (oldPosition > player.queue.tracks.length || newPosition > player.queue.tracks.length) {
-			await interaction.replyHandler.localeError('CMD_MOVE_NOT_IN_RANGE');
+			await interaction.replyHandler.locale('CMD_MOVE_NOT_IN_RANGE', {}, 'error');
 			return;
 		}
 		if (oldPosition === newPosition) {
-			await interaction.replyHandler.localeError('CMD_MOVE_EQUAL');
+			await interaction.replyHandler.locale('CMD_MOVE_EQUAL', {}, 'error');
 			return;
 		}
 		player.queue.tracks.splice(newPosition - 1, 0, player.queue.tracks.splice(oldPosition - 1, 1)[0]);
 		const track = player.queue.tracks[newPosition - 1];
-		await interaction.replyHandler.locale('CMD_MOVE_SUCCESS', {}, track.title, track.uri, oldPosition, newPosition);
+		await interaction.replyHandler.locale('CMD_MOVE_SUCCESS', {}, 'success', track.title, track.uri, oldPosition, newPosition);
 	},
 };

--- a/commands/nightcore.js
+++ b/commands/nightcore.js
@@ -31,6 +31,6 @@ module.exports = {
 		player.filters.timescale = nightcore ? { speed: 1.125, pitch: 1.125, rate: 1 } : undefined;
 		await player.setFilters();
 		player.nightcore = nightcore;
-		await interaction.replyHandler.locale(player.nightcore ? 'CMD_NIGHTCORE_ENABLED' : 'CMD_NIGHTCORE_DISABLED', { footer: getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_FILTERS_NOTE') });
+		await interaction.replyHandler.locale(player.nightcore ? 'CMD_NIGHTCORE_ENABLED' : 'CMD_NIGHTCORE_DISABLED', { footer: getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_FILTERS_NOTE') }, 'neutral');
 	},
 };

--- a/commands/pause.js
+++ b/commands/pause.js
@@ -16,10 +16,10 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (player.paused) {
-			await interaction.replyHandler.localeError('CMD_PAUSE_PAUSED');
+			await interaction.replyHandler.locale('CMD_PAUSE_PAUSED', {}, 'error');
 			return;
 		}
 		player.pause();
-		await interaction.replyHandler.locale('CMD_PAUSE_SUCCESS');
+		await interaction.replyHandler.locale('CMD_PAUSE_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -16,6 +16,6 @@ module.exports = {
 	async execute(interaction) {
 		const uptime = msToTime(interaction.client.uptime);
 		const uptimeString = msToTimeString(uptime);
-		await interaction.replyHandler.locale('CMD_PING_PONG', { footer: `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'CMD_PING_UPTIME')} ${uptimeString}` }, interaction.guild ? ` ${interaction.guild.shard.ping}ms` : '');
+		await interaction.replyHandler.locale('CMD_PING_PONG', { footer: `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'CMD_PING_UPTIME')} ${uptimeString}` }, 'neutral', interaction.guild ? ` ${interaction.guild.shard.ping}ms` : '');
 	},
 };

--- a/commands/play.js
+++ b/commands/play.js
@@ -27,21 +27,21 @@ module.exports = {
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client & {music: import('lavaclient').Node}, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (![ChannelType.GuildText, ChannelType.GuildVoice].includes(interaction.channel.type)) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_UNSUPPORTED_CHANNEL');
+			await interaction.replyHandler.locale('DISCORD_BOT_UNSUPPORTED_CHANNEL', {}, 'error');
 			return;
 		}
 		// check for connect, speak permission for channel
 		const permissions = interaction.member.voice.channel.permissionsFor(interaction.client.user.id);
 		if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+			await interaction.replyHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'error');
 			return;
 		}
 		if (interaction.member.voice.channel.type === ChannelType.GuildStageVoice && !permissions.has(PermissionsBitField.StageModerator)) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
+			await interaction.replyHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE', {}, 'error');
 			return;
 		}
 		if (interaction.guild.members.me.isCommunicationDisabled()) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT');
+			await interaction.replyHandler.locale('DISCORD_BOT_TIMED_OUT', {}, 'error');
 			return;
 		}
 
@@ -66,7 +66,7 @@ module.exports = {
 					extras = [tracks.length, item.name, query];
 					break;
 				default:
-					await interaction.replyHandler.localeError('CMD_PLAY_SPOTIFY_NO_RESULTS');
+					await interaction.replyHandler.locale('CMD_PLAY_SPOTIFY_NO_RESULTS', {}, 'error');
 					return;
 			}
 		}
@@ -87,13 +87,13 @@ module.exports = {
 					break;
 				}
 				case 'NO_MATCHES':
-					await interaction.replyHandler.localeError('CMD_PLAY_NO_RESULTS');
+					await interaction.replyHandler.locale('CMD_PLAY_NO_RESULTS', {}, 'error');
 					return;
 				case 'LOAD_FAILED':
-					await interaction.replyHandler.localeError('CMD_PLAY_LOAD_FAILED');
+					await interaction.replyHandler.locale('CMD_PLAY_LOAD_FAILED', {}, 'error');
 					return;
 				default:
-					await interaction.replyHandler.localeError('DISCORD_CMD_ERROR');
+					await interaction.replyHandler.locale('DISCORD_CMD_ERROR', {}, 'error');
 					return;
 			}
 		}
@@ -109,7 +109,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
-				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, interaction.user.id);
+				if (interaction.guild) timedOut ? await interaction.replyHandler.locale('DISCORD_BOT_TIMED_OUT', {}, 'error') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', {}, 'neutral', interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}
@@ -121,7 +121,7 @@ module.exports = {
 		player.queue.add(tracks, { requester: interaction.user.id, next: insert });
 
 		const started = player.playing || player.paused;
-		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }, ...extras);
+		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }, 'success', ...extras);
 		if (!started) { await player.queue.start(); }
 	},
 };

--- a/commands/playing.js
+++ b/commands/playing.js
@@ -19,7 +19,7 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		// workaround: seems like current track doesn't get removed after the track, an issue with @lavaclient/queue
 		if (!player.queue.current || !player.playing && !player.paused) {
-			await interaction.replyHandler.localeError('MUSIC_QUEUE_NOT_PLAYING');
+			await interaction.replyHandler.locale('MUSIC_QUEUE_NOT_PLAYING', {}, 'error');
 			return;
 		}
 		const bar = getBar((player.position / player.queue.current.length) * 100);

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -18,7 +18,7 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		const pages = paginate(player.queue.tracks, 5);
 		if (player.queue.tracks.length === 0) {
-			await interaction.replyHandler.localeError('CMD_QUEUE_EMPTY');
+			await interaction.replyHandler.locale('CMD_QUEUE_EMPTY', {}, 'error');
 			return;
 		}
 		await interaction.replyHandler.reply(

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -23,18 +23,18 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		const position = interaction.options.getInteger('position');
 		if (player.queue.tracks.length === 0) {
-			await interaction.replyHandler.localeError('CMD_REMOVE_EMPTY');
+			await interaction.replyHandler.locale('CMD_REMOVE_EMPTY', {}, 'error');
 			return;
 		}
 		if (position > player.queue.tracks.length) {
-			await interaction.replyHandler.localeError('CHECK_INVALID_INDEX');
+			await interaction.replyHandler.locale('CHECK_INVALID_INDEX', {}, 'error');
 			return;
 		}
 		if (player.queue.tracks[position - 1].requester !== interaction.user.id) {
-			await interaction.replyHandler.localeError('CHECK_NOT_REQUESTER');
+			await interaction.replyHandler.locale('CHECK_NOT_REQUESTER', {}, 'error');
 			return;
 		}
 		const track = player.queue.remove(position - 1);
-		await interaction.replyHandler.locale('CMD_REMOVE_SUCCESS', {}, track.title, track.uri);
+		await interaction.replyHandler.locale('CMD_REMOVE_SUCCESS', {}, 'success', track.title, track.uri);
 	},
 };

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -16,10 +16,10 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (!player.paused) {
-			await interaction.replyHandler.localeError('CMD_RESUME_UNPAUSED');
+			await interaction.replyHandler.locale('CMD_RESUME_UNPAUSED', {}, 'error');
 			return;
 		}
 		player.resume();
-		await interaction.replyHandler.locale('CMD_RESUME_SUCCESS');
+		await interaction.replyHandler.locale('CMD_RESUME_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, SelectMenuBuilder, ButtonBuilder, ButtonStyle, ChannelType } = require('discord.js');
 const { checks } = require('../enums.js');
 const { getLocale, msToTime, msToTimeString } = require('../functions.js');
-const { defaultColor, defaultLocale } = require('../settings.json');
+const { colors, defaultLocale } = require('../settings.json');
 const { data } = require('../shared.js');
 
 // credit: https://github.com/lavaclient/djs-v13-example/blob/main/src/commands/Play.ts
@@ -23,7 +23,7 @@ module.exports = {
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (![ChannelType.GuildText, ChannelType.GuildVoice].includes(interaction.channel.type)) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_UNSUPPORTED_CHANNEL');
+			await interaction.replyHandler.locale('DISCORD_BOT_UNSUPPORTED_CHANNEL', {}, 'error');
 			return;
 		}
 		await interaction.deferReply();
@@ -35,7 +35,7 @@ module.exports = {
 
 		tracks = tracks.slice(0, 10);
 		if (tracks.length <= 1) {
-			await interaction.replyHandler.localeError('CMD_SEARCH_USE_PLAY_CMD');
+			await interaction.replyHandler.locale('CMD_SEARCH_USE_PLAY_CMD', {}, 'error');
 			return;
 		}
 
@@ -47,7 +47,7 @@ module.exports = {
 						const durationString = track.info.isStream ? '∞' : msToTimeString(duration, true);
 						return `\`${(index + 1).toString().padStart(tracks.length.toString().length, ' ')}.\` **[${track.info.title}](${track.info.uri})** \`[${durationString}]\``;
 					}).join('\n'))
-					.setColor(defaultColor),
+					.setColor(colors.neutral),
 			],
 			components: [
 				new ActionRowBuilder()

--- a/commands/seek.js
+++ b/commands/seek.js
@@ -34,29 +34,29 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (!player.queue.current || !player.playing && !player.paused) {
-			await interaction.replyHandler.localeError('MUSIC_QUEUE_NOT_PLAYING');
+			await interaction.replyHandler.locale('MUSIC_QUEUE_NOT_PLAYING', {}, 'error');
 			return;
 		}
 		if (player.queue.current.isStream) {
-			await interaction.replyHandler.localeError('CMD_SEEK_IS_STREAM');
+			await interaction.replyHandler.locale('CMD_SEEK_IS_STREAM', {}, 'error');
 			return;
 		}
 		const hours = interaction.options.getInteger('hours') ?? 0, minutes = interaction.options.getInteger('minutes') ?? 0, seconds = interaction.options.getInteger('seconds') ?? 0;
 		const ms = hours * 3600000 + minutes * 60000 + seconds * 1000;
 		if (interaction.options.getInteger('hours') === null && interaction.options.getInteger('minutes') === null && interaction.options.getInteger('seconds') === null) {
-			await interaction.replyHandler.localeError('CMD_SEEK_UNSPECIFIED_TIMESTAMP');
+			await interaction.replyHandler.locale('CMD_SEEK_UNSPECIFIED_TIMESTAMP', {}, 'error');
 			return;
 		}
 		const trackLength = player.queue.current.length;
 		const duration = msToTime(trackLength);
 		const durationString = msToTimeString(duration, true);
 		if (ms > trackLength) {
-			await interaction.replyHandler.localeError('CMD_SEEK_INVALID_TIMESTAMP', {}, durationString);
+			await interaction.replyHandler.locale('CMD_SEEK_INVALID_TIMESTAMP', {}, 'error', durationString);
 			return;
 		}
 		const seek = msToTime(ms);
 		const seekString = msToTimeString(seek, true);
 		await player.seek(ms);
-		await interaction.replyHandler.locale('CMD_SEEK_SUCCESS', {}, seekString, durationString);
+		await interaction.replyHandler.locale('CMD_SEEK_SUCCESS', {}, 'neutral', seekString, durationString);
 	},
 };

--- a/commands/shuffle.js
+++ b/commands/shuffle.js
@@ -16,7 +16,7 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (player.queue.tracks.length <= 1) {
-			await interaction.replyHandler.localeError('CMD_SHUFFLE_INSUFFICIENT');
+			await interaction.replyHandler.locale('CMD_SHUFFLE_INSUFFICIENT', {}, 'error');
 			return;
 		}
 		let currentIndex = player.queue.tracks.length, randomIndex;
@@ -25,6 +25,6 @@ module.exports = {
 			currentIndex--;
 			[player.queue.tracks[currentIndex], player.queue.tracks[randomIndex]] = [player.queue.tracks[randomIndex], player.queue.tracks[currentIndex]];
 		}
-		await interaction.replyHandler.locale('CMD_SHUFFLE_SUCCESS');
+		await interaction.replyHandler.locale('CMD_SHUFFLE_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -17,18 +17,18 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (!player.queue.current || !player.playing && !player.paused) {
-			await interaction.replyHandler.localeError('MUSIC_QUEUE_NOT_PLAYING');
+			await interaction.replyHandler.locale('MUSIC_QUEUE_NOT_PLAYING', {}, 'error');
 			return;
 		}
 		if (player.queue.current.requester === interaction.user.id) {
 			const track = await player.queue.skip();
 			await player.queue.start();
-			await interaction.replyHandler.locale('CMD_SKIP_SUCCESS', {}, track.title, track.uri);
+			await interaction.replyHandler.locale('CMD_SKIP_SUCCESS', {}, 'success', track.title, track.uri);
 			return;
 		}
 		const skip = player.skip ?? { required: Math.ceil(interaction.member.voice.channel.members.size / 2), users: [] };
 		if (skip.users.includes(interaction.user.id)) {
-			await interaction.replyHandler.localeError('CMD_SKIP_VOTED');
+			await interaction.replyHandler.locale('CMD_SKIP_VOTED', {}, 'error');
 			return;
 		}
 		skip.users.push(interaction.user.id);
@@ -40,6 +40,6 @@ module.exports = {
 			return;
 		}
 		player.skip = skip;
-		await interaction.replyHandler.locale('CMD_SKIP_VOTED_SUCCESS', {}, player.queue.current.title, player.queue.current.uri, skip.users.length, skip.required);
+		await interaction.replyHandler.locale('CMD_SKIP_VOTED_SUCCESS', {}, 'success', player.queue.current.title, player.queue.current.uri, skip.users.length, skip.required);
 	},
 };

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -16,12 +16,12 @@ module.exports = {
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		if (!player.queue.current || !player.playing && !player.paused) {
-			await interaction.replyHandler.localeError('MUSIC_QUEUE_NOT_PLAYING');
+			await interaction.replyHandler.locale('MUSIC_QUEUE_NOT_PLAYING', {}, 'error');
 			return;
 		}
 		player.queue.clear();
 		await player.queue.skip();
 		await player.queue.start();
-		await interaction.replyHandler.locale('CMD_STOP_SUCCESS');
+		await interaction.replyHandler.locale('CMD_STOP_SUCCESS', {}, 'success');
 	},
 };

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -25,10 +25,10 @@ module.exports = {
 		const player = interaction.client.music.players.get(interaction.guildId);
 		const volume = interaction.options.getInteger('new_volume');
 		if (volume > 200 && !managers.includes(interaction.user.id)) {
-			await interaction.replyHandler.localeError('CMD_VOLUME_NOT_IN_RANGE');
+			await interaction.replyHandler.locale('CMD_VOLUME_NOT_IN_RANGE', {}, 'error');
 			return;
 		}
 		await player.setVolume(volume);
-		await interaction.replyHandler.locale('CMD_VOLUME_SUCCESS', { footer: getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_FILTERS_NOTE') }, volume);
+		await interaction.replyHandler.locale('CMD_VOLUME_SUCCESS', { footer: getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_FILTERS_NOTE') }, 'neutral', volume);
 	},
 };

--- a/components/buttons/cancel.js
+++ b/components/buttons/cancel.js
@@ -1,14 +1,14 @@
 const { EmbedBuilder } = require('discord.js');
 const { logger, data } = require('../../shared.js');
 const { getLocale } = require('../../functions.js');
-const { defaultLocale, defaultColor } = require('../../settings.json');
+const { defaultLocale, colors } = require('../../settings.json');
 
 module.exports = {
 	name: 'cancel',
 	/** @param {import('discord.js').ButtonInteraction & {replyHandler: import('../../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (interaction.customId.split('_')[1] !== interaction.user.id) {
-			await interaction.replyHandler.localeError('DISCORD_INTERACTION_WRONG_USER');
+			await interaction.replyHandler.locale('DISCORD_INTERACTION_WRONG_USER', {}, 'error');
 			return;
 		}
 		try {
@@ -16,7 +16,7 @@ module.exports = {
 				embeds: [
 					new EmbedBuilder()
 						.setDescription(getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'DISCORD_INTERACTION_CANCELED', interaction.user.id))
-						.setColor(defaultColor),
+						.setColor(colors.neutral),
 				],
 				components: [],
 			});

--- a/components/selects/play.js
+++ b/components/selects/play.js
@@ -10,31 +10,31 @@ module.exports = {
 	/** @param {import('discord.js').SelectMenuInteraction & {client: import('discord.js').Client & {music: import('lavaclient').Node}, replyHandler: import('../../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		if (interaction.customId.split('_')[1] !== interaction.user.id) {
-			await interaction.replyHandler.localeError('DISCORD_INTERACTION_WRONG_USER');
+			await interaction.replyHandler.locale('DISCORD_INTERACTION_WRONG_USER', {}, 'error');
 			return;
 		}
 		const tracks = interaction.values;
 		let player = interaction.client.music.players.get(interaction.guildId);
 		if (!interaction.member?.voice.channelId) {
-			await interaction.replyHandler.localeError(checks.IN_VOICE);
+			await interaction.replyHandler.locale(checks.IN_VOICE, {}, 'error');
 			return;
 		}
 		if (player && interaction.member?.voice.channelId !== player.channelId) {
-			await interaction.replyHandler.localeError(checks.IN_SESSION_VOICE);
+			await interaction.replyHandler.locale(checks.IN_SESSION_VOICE, {}, 'error');
 			return;
 		}
 		// check for connect, speak permission for channel
 		const permissions = interaction.member?.voice.channel.permissionsFor(interaction.client.user.id);
 		if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+			await interaction.replyHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'error');
 			return;
 		}
 		if (interaction.member?.voice.channel.type === ChannelType.GuildStageVoice && !permissions.has(PermissionsBitField.StageModerator)) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_MISSING_PERMISSIONS_STAGE');
+			await interaction.replyHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS_STAGE', {}, 'error');
 			return;
 		}
 		if (interaction.guild.members.me.isCommunicationDisabled()) {
-			await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT');
+			await interaction.replyHandler.locale('DISCORD_BOT_TIMED_OUT', {}, 'error');
 			return;
 		}
 
@@ -65,7 +65,7 @@ module.exports = {
 			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
 			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
 			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
-				if (interaction.guild) timedOut ? await interaction.replyHandler.localeError('DISCORD_BOT_TIMED_OUT', { components: [] }) : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, interaction.user.id);
+				if (interaction.guild) timedOut ? await interaction.replyHandler.locale('DISCORD_BOT_TIMED_OUT', { components: [] }, 'error') : await interaction.replyHandler.locale('DISCORD_INTERACTION_CANCELED', { components: [] }, 'neutral', interaction.user.id);
 				await player.handler.disconnect();
 				return;
 			}
@@ -76,7 +76,7 @@ module.exports = {
 		player.queue.add(resolvedTracks, { requester: interaction.user.id });
 
 		const started = player.playing || player.paused;
-		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null, components: [] }, ...extras);
+		await interaction.replyHandler.locale(msg, { footer: started ? `${getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'MISC_POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null, components: [] }, 'success', ...extras);
 		if (!started) { await player.queue.start(); }
 	},
 };

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -49,7 +49,7 @@ module.exports = {
 			}
 			if (failedChecks.length > 0) {
 				logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Command ${interaction.commandName} failed ${failedChecks.length} check(s)`, label: 'Quaver' });
-				await interaction.replyHandler.localeError(failedChecks[0]);
+				await interaction.replyHandler.locale(failedChecks[0], {}, 'error');
 				return;
 			}
 			const failedPermissions = { user: [], bot: [] };
@@ -63,12 +63,12 @@ module.exports = {
 			}
 			if (failedPermissions.user.length > 0) {
 				logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Command ${interaction.commandName} failed ${failedPermissions.user.length} user permission check(s)`, label: 'Quaver' });
-				await interaction.replyHandler.localeError('DISCORD_USER_MISSING_PERMISSIONS', {}, failedPermissions.user.map(perm => `\`${perm}\``).join(' '));
+				await interaction.replyHandler.locale('DISCORD_USER_MISSING_PERMISSIONS', {}, 'error', failedPermissions.user.map(perm => `\`${perm}\``).join(' '));
 				return;
 			}
 			if (failedPermissions.bot.length > 0) {
 				logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Command ${interaction.commandName} failed ${failedPermissions.bot.length} bot permission check(s)`, label: 'Quaver' });
-				await interaction.replyHandler.localeError('DISCORD_BOT_MISSING_PERMISSIONS', {}, failedPermissions.bot.map(perm => `\`${perm}\``).join(' '));
+				await interaction.replyHandler.locale('DISCORD_BOT_MISSING_PERMISSIONS', {}, 'error', failedPermissions.bot.map(perm => `\`${perm}\``).join(' '));
 				return;
 			}
 			try {
@@ -78,7 +78,7 @@ module.exports = {
 			catch (err) {
 				logger.error({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Encountered error with command ${interaction.commandName}`, label: 'Quaver' });
 				logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
-				await interaction.replyHandler.localeError('DISCORD_GENERIC_ERROR');
+				await interaction.replyHandler.locale('DISCORD_GENERIC_ERROR', {}, 'error');
 			}
 		}
 		else if (interaction.isButton()) {
@@ -93,7 +93,7 @@ module.exports = {
 			catch (err) {
 				logger.error({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Encountered error with button ${interaction.customId}`, label: 'Quaver' });
 				logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
-				await interaction.replyHandler.localeError('DISCORD_GENERIC_ERROR');
+				await interaction.replyHandler.locale('DISCORD_GENERIC_ERROR', {}, 'error');
 			}
 		}
 		else if (interaction.isSelectMenu()) {
@@ -108,7 +108,7 @@ module.exports = {
 			catch (err) {
 				logger.error({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Encountered error with select menu ${interaction.customId}`, label: 'Quaver' });
 				logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
-				await interaction.replyHandler.localeError('DISCORD_GENERIC_ERROR');
+				await interaction.replyHandler.locale('DISCORD_GENERIC_ERROR', {}, 'error');
 			}
 		}
 	},

--- a/events/music/queueFinish.js
+++ b/events/music/queueFinish.js
@@ -8,7 +8,7 @@ module.exports = {
 	/** @param {import('@lavaclient/queue').Queue & {player: import('lavaclient').Player & {handler: import('../../classes/PlayerHandler.js')}}} queue */
 	async execute(queue) {
 		if (await data.guild.get(queue.player.guildId, 'settings.stay.enabled')) {
-			await queue.player.handler.locale('MUSIC_QUEUE_EMPTY');
+			await queue.player.handler.locale('MUSIC_QUEUE_EMPTY', {}, 'neutral');
 			return;
 		}
 		// rare case where the bot sets timeout after setting pause timeout
@@ -19,9 +19,9 @@ module.exports = {
 		}
 		queue.player.timeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
-			p.handler.locale('MUSIC_INACTIVITY');
+			p.handler.locale('MUSIC_INACTIVITY', {}, 'warning');
 			p.handler.disconnect();
 		}, 1800000, queue.player);
-		await queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`);
+		await queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_QUEUE_EMPTY')} ${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 1800)}`, {}, 'warning');
 	},
 };

--- a/events/music/trackEnd.js
+++ b/events/music/trackEnd.js
@@ -13,11 +13,11 @@ module.exports = {
 		delete queue.player.skip;
 		if (reason === 'LOAD_FAILED') {
 			logger.warn({ message: `[G ${queue.player.guildId}] Track skipped with reason: ${reason}`, label: 'Quaver' });
-			await queue.player.handler.locale('MUSIC_TRACK_SKIPPED', {}, true, track.title, track.uri, reason);
+			await queue.player.handler.locale('MUSIC_TRACK_SKIPPED', {}, 'warning', track.title, track.uri, reason);
 		}
 		if (bot.guilds.cache.get(queue.player.guildId).channels.cache.get(queue.player.channelId).members?.filter(m => !m.user.bot).size < 1 && !await data.guild.get(queue.player.guildId, 'settings.stay.enabled')) {
 			logger.info({ message: `[G ${queue.player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
-			await queue.player.handler.locale('MUSIC_ALONE');
+			await queue.player.handler.locale('MUSIC_ALONE', {}, 'warning');
 			await queue.player.handler.disconnect();
 			return;
 		}

--- a/events/music/trackStart.js
+++ b/events/music/trackStart.js
@@ -18,6 +18,6 @@ module.exports = {
 		}
 		const duration = msToTime(track.length);
 		const durationString = track.isStream ? '∞' : msToTimeString(duration, true);
-		await queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_NOW_PLAYING', track.title, track.uri, durationString)}\n${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ADDED_BY', track.requester)}`);
+		await queue.player.handler.send(`${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_NOW_PLAYING', track.title, track.uri, durationString)}\n${getLocale(await data.guild.get(queue.player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ADDED_BY', track.requester)}`, {}, 'neutral');
 	},
 };

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -37,7 +37,7 @@ module.exports = {
 				// Check for connect, speak permission for voice channel
 				const permissions = oldState.client.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(oldState.client.user.id);
 				if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'warning');
+					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'error');
 					await player.handler.disconnect();
 					return;
 				}
@@ -51,7 +51,7 @@ module.exports = {
 				const permissions = oldState.client.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(oldState.client.user.id);
 				// Check for connect, speak permission for stage channel
 				if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'warning');
+					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'error');
 					await player.handler.disconnect();
 					return;
 				}

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -27,7 +27,7 @@ module.exports = {
 				if (await data.guild.get(player.guildId, 'settings.stay.enabled')) {
 					await data.guild.set(player.guildId, 'settings.stay.enabled', false);
 				}
-				await player.handler.locale('MUSIC_FORCED');
+				await player.handler.locale('MUSIC_FORCED', {}, 'warning');
 				await player.handler.disconnect(oldState.channelId);
 				return;
 			}
@@ -37,7 +37,7 @@ module.exports = {
 				// Check for connect, speak permission for voice channel
 				const permissions = oldState.client.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(oldState.client.user.id);
 				if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'warning');
 					await player.handler.disconnect();
 					return;
 				}
@@ -51,7 +51,7 @@ module.exports = {
 				const permissions = oldState.client.guilds.cache.get(guild.id).channels.cache.get(newState.channelId).permissionsFor(oldState.client.user.id);
 				// Check for connect, speak permission for stage channel
 				if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) {
-					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC');
+					await player.handler.locale('DISCORD_BOT_MISSING_PERMISSIONS_BASIC', {}, 'warning');
 					await player.handler.disconnect();
 					return;
 				}
@@ -59,7 +59,7 @@ module.exports = {
 					if (await data.guild.get(player.guildId, 'settings.stay.enabled')) {
 						await data.guild.set(player.guildId, 'settings.stay.enabled', false);
 					}
-					await player.handler.locale('MUSIC_FORCED_STAGE');
+					await player.handler.locale('MUSIC_FORCED_STAGE', {}, 'warning');
 					await player.handler.disconnect();
 					return;
 				}
@@ -85,7 +85,7 @@ module.exports = {
 						await data.guild.set(player.guildId, 'settings.stay.enabled', false);
 					}
 					logger.info({ message: `[G ${player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
-					await player.handler.locale('MUSIC_ALONE_MOVED');
+					await player.handler.locale('MUSIC_ALONE_MOVED', {}, 'warning');
 					await player.handler.disconnect();
 					return;
 				}
@@ -101,10 +101,10 @@ module.exports = {
 				clearTimeout(player.pauseTimeout);
 				player.pauseTimeout = setTimeout(p => {
 					logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
-					p.handler.locale('MUSIC_INACTIVITY');
+					p.handler.locale('MUSIC_INACTIVITY', {}, 'warning');
 					p.handler.disconnect();
 				}, 300000, player);
-				await player.handler.send(`${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
+				await player.handler.send(`${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_REJOIN') }, 'warning');
 			}
 			// Moved to a new channel that has humans and pauseTimeout is set
 			else if (newState.channel.members.filter(m => !m.user.bot).size >= 1 && player.pauseTimeout) {
@@ -112,7 +112,7 @@ module.exports = {
 				player.resume();
 				clearTimeout(player.pauseTimeout);
 				delete player.pauseTimeout;
-				await player.handler.locale('MUSIC_ALONE_RESUMED');
+				await player.handler.locale('MUSIC_ALONE_RESUMED', {}, 'success');
 				return;
 			}
 		}
@@ -128,7 +128,7 @@ module.exports = {
 				clearTimeout(player.pauseTimeout);
 				delete player.pauseTimeout;
 			}
-			await player.handler.locale('MUSIC_ALONE_RESUMED');
+			await player.handler.locale('MUSIC_ALONE_RESUMED', {}, 'success');
 			return;
 		}
 		// User not in our channel
@@ -143,7 +143,7 @@ module.exports = {
 		// Nothing is playing so we'll leave
 		if (!player.queue.current || !player.playing && !player.paused) {
 			logger.info({ message: `[G ${player.guildId}] Disconnecting (alone)`, label: 'Quaver' });
-			await player.handler.locale('MUSIC_ALONE');
+			await player.handler.locale('MUSIC_ALONE', {}, 'warning');
 			await player.handler.disconnect();
 			return;
 		}
@@ -159,9 +159,9 @@ module.exports = {
 		clearTimeout(player.pauseTimeout);
 		player.pauseTimeout = setTimeout(p => {
 			logger.info({ message: `[G ${p.guildId}] Disconnecting (inactivity)`, label: 'Quaver' });
-			p.handler.locale('MUSIC_INACTIVITY');
+			p.handler.locale('MUSIC_INACTIVITY', {}, 'warning');
 			p.handler.disconnect();
 		}, 300000, player);
-		await player.handler.send(`${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_REJOIN') });
+		await player.handler.send(`${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_WARNING')} ${getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_INACTIVITY_WARNING', Math.floor(Date.now() / 1000) + 300)}`, { footer: getLocale(await data.guild.get(player.guildId, 'settings.locale') ?? defaultLocale, 'MUSIC_ALONE_REJOIN') }, 'warning');
 	},
 };

--- a/main.js
+++ b/main.js
@@ -143,6 +143,7 @@ async function shuttingDown(eventType, err) {
 						},
 					] : [],
 				},
+				'warning',
 			);
 			if (!success) continue;
 		}

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,7 +1,12 @@
 {
   "token": "Paste token here",
   "applicationId": "Paste application ID here",
-  "defaultColor": "#f39bff",
+  "colors": {
+    "success": "DarkGreen",
+    "neutral": "#f39bff",
+    "warning": "DarkOrange",
+    "error": "DarkRed"
+  },
   "defaultLocale": "en",
   "managers": [
     "Paste your user ID here"

--- a/settings.example.json
+++ b/settings.example.json
@@ -4,7 +4,7 @@
   "colors": {
     "success": "DarkGreen",
     "neutral": "#f39bff",
-    "warning": "DarkOrange",
+    "warning": "Orange",
     "error": "DarkRed"
   },
   "defaultLocale": "en",


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Closes #328
Renames defaultColor to colors
Adds "success", "warning", "neutral", "error" variants
Adds a default color for each in `settings.example.json`
Relevant documentation added alongside the changes
JSDoc documented for the method changes
Also removes relevant "Error" methods, combining them into the pre-existing method, defined by the "type" argument

expect changes to the handler methods in another PR