### PR TITLE
refactor(command-queue): paginate only when there are tracks

### DIFF
--- a/commands/queue.js
+++ b/commands/queue.js
@@ -16,11 +16,11 @@ module.exports = {
 	/** @param {import('discord.js').CommandInteraction & {client: import('discord.js').Client & {music: import('lavaclient').Node}, replyHandler: import('../classes/ReplyHandler.js')}} interaction */
 	async execute(interaction) {
 		const player = interaction.client.music.players.get(interaction.guildId);
-		const pages = paginate(player.queue.tracks, 5);
 		if (player.queue.tracks.length === 0) {
 			await interaction.replyHandler.locale('CMD_QUEUE_EMPTY', {}, 'error');
 			return;
 		}
+		const pages = paginate(player.queue.tracks, 5);
 		await interaction.replyHandler.reply(
 			pages[0].map((track, index) => {
 				const duration = msToTime(track.length);


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.

Moves a constant below an if statement. No need to paginate when there are no tracks. Makes it return earlier when there are no tracks. 