### PR TITLE
refactor: use try-catch-finally in shuttingDown()

### DIFF
--- a/main.js
+++ b/main.js
@@ -149,6 +149,11 @@ async function shuttingDown(eventType, err) {
 				if (!success) continue;
 			}
 		}
+	}
+	catch (error) {
+		logger.error({ message: `Encountered error while shutting down.\n${error.message}\n${error.stack}`, label: 'Quaver' });
+	}
+	finally {
 		if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {
 			logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
 			logger.info({ message: 'Logging additional output to error.log.', label: 'Quaver' });
@@ -160,11 +165,6 @@ async function shuttingDown(eventType, err) {
 				logger.error({ message: `${e.message}\n${e.stack}`, label: 'Quaver' });
 			}
 		}
-	}
-	catch (error) {
-		logger.error({ message: `Encountered error while shutting down.\n${error.message}\n${error.stack}`, label: 'Quaver' });
-	}
-	finally {
 		bot.destroy();
 		process.exit();
 	}

--- a/main.js
+++ b/main.js
@@ -151,7 +151,8 @@ async function shuttingDown(eventType, err) {
 		}
 	}
 	catch (error) {
-		logger.error({ message: `Encountered error while shutting down.\n${error.message}\n${error.stack}`, label: 'Quaver' });
+		logger.error({ message: 'Encountered error while shutting down.', label: 'Quaver' });
+		logger.error({ message: `${error.message}\n${error.stack}`, label: 'Quaver' });
 	}
 	finally {
 		if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {

--- a/main.js
+++ b/main.js
@@ -161,8 +161,8 @@ async function shuttingDown(eventType, err) {
 			}
 		}
 	}
-	catch (err) {
-		logger.error({ message: `Encountered error while shutting down.\n${err.message}\n${err.stack}`, label: 'Quaver' });
+	catch (error) {
+		logger.error({ message: `Encountered error while shutting down.\n${error.message}\n${error.stack}`, label: 'Quaver' });
 	}
 	finally {
 		bot.destroy();

--- a/main.js
+++ b/main.js
@@ -115,52 +115,59 @@ async function shuttingDown(eventType, err) {
 	if (inProgress) return;
 	inProgress = true;
 	logger.info({ message: 'Shutting down...', label: 'Quaver' });
-	if (module.exports.startup) {
-		logger.info({ message: 'Disconnecting from all guilds...', label: 'Quaver' });
-		for (const pair of bot.music.players) {
+	try {
+		if (module.exports.startup) {
+			logger.info({ message: 'Disconnecting from all guilds...', label: 'Quaver' });
+			for (const pair of bot.music.players) {
 			/** @type {import('lavaclient').Player & {handler: import('./classes/PlayerHandler.js')}} */
-			const player = pair[1];
-			/** @type {string} */
-			const guildLocale = await data.guild.get(player.guildId, 'settings.locale');
-			logger.info({ message: `[G ${player.guildId}] Disconnecting (restarting)`, label: 'Quaver' });
-			const fileBuffer = [];
-			if (player.queue.current && (player.playing || player.paused)) {
-				fileBuffer.push(`${getLocale(guildLocale ?? defaultLocale, 'MISC_CURRENT')}:`);
-				fileBuffer.push(player.queue.current.uri);
+				const player = pair[1];
+				/** @type {string} */
+				const guildLocale = await data.guild.get(player.guildId, 'settings.locale');
+				logger.info({ message: `[G ${player.guildId}] Disconnecting (restarting)`, label: 'Quaver' });
+				const fileBuffer = [];
+				if (player.queue.current && (player.playing || player.paused)) {
+					fileBuffer.push(`${getLocale(guildLocale ?? defaultLocale, 'MISC_CURRENT')}:`);
+					fileBuffer.push(player.queue.current.uri);
+				}
+				if (player.queue.tracks.length > 0) {
+					fileBuffer.push(`${getLocale(guildLocale ?? defaultLocale, 'MISC_QUEUE')}:`);
+					fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
+				}
+				await player.handler.disconnect();
+				const success = await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
+					{
+						footer: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY'),
+						files: fileBuffer.length > 0 ? [
+							{
+								attachment: Buffer.from(fileBuffer.join('\n')),
+								name: 'queue.txt',
+							},
+						] : [],
+					},
+					'warning',
+				);
+				if (!success) continue;
 			}
-			if (player.queue.tracks.length > 0) {
-				fileBuffer.push(`${getLocale(guildLocale ?? defaultLocale, 'MISC_QUEUE')}:`);
-				fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
+		}
+		if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {
+			logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
+			logger.info({ message: 'Logging additional output to error.log.', label: 'Quaver' });
+			try {
+				await fsPromises.writeFile('error.log', `${eventType}${err.message ? `\n${err.message}` : ''}${err.stack ? `\n${err.stack}` : ''}`);
 			}
-			await player.handler.disconnect();
-			const success = await player.handler.send(`${getLocale(guildLocale ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC_RESTART' : 'MUSIC_RESTART_CRASH')}${fileBuffer.length > 0 ? `\n${getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_QUEUEDATA')}` : ''}`,
-				{
-					footer: getLocale(guildLocale ?? defaultLocale, 'MUSIC_RESTART_SORRY'),
-					files: fileBuffer.length > 0 ? [
-						{
-							attachment: Buffer.from(fileBuffer.join('\n')),
-							name: 'queue.txt',
-						},
-					] : [],
-				},
-				'warning',
-			);
-			if (!success) continue;
+			catch (e) {
+				logger.error({ message: 'Encountered error while writing to error.log.', label: 'Quaver' });
+				logger.error({ message: `${e.message}\n${e.stack}`, label: 'Quaver' });
+			}
 		}
 	}
-	if (!['exit', 'SIGINT', 'SIGTERM'].includes(eventType)) {
-		logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
-		logger.info({ message: 'Logging additional output to error.log.', label: 'Quaver' });
-		try {
-			await fsPromises.writeFile('error.log', `${eventType}${err.message ? `\n${err.message}` : ''}${err.stack ? `\n${err.stack}` : ''}`);
-		}
-		catch (e) {
-			logger.error({ message: 'Encountered error while writing to error.log.', label: 'Quaver' });
-			logger.error({ message: `${e.message}\n${e.stack}`, label: 'Quaver' });
-		}
+	catch (err) {
+		logger.error({ message: `Encountered error while shutting down.\n${err.message}\n${err.stack}`, label: 'Quaver' });
 	}
-	bot.destroy();
-	process.exit();
+	finally {
+		bot.destroy();
+		process.exit();
+	}
 }
 module.exports.shuttingDown = shuttingDown;
 


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Affects functionality.
Closes #416
On `shuttingDown()` invocation, Quaver should no longer get stuck whatever happens inside `shuttingDown()`

In the `try` clause is where Quaver does what it should do when shutting down, cleaning up.
In the `catch` clause, we only log the error(s) that occurs in the `try` clause.
In the `finally` clause, we should `destroy()` the bot and `process.exit()` no matter what the outcome is.
