### PR TITLE
chore(scripts): update REST and discord-api-types used to v10

### DIFF
--- a/scripts/delete-commands.js
+++ b/scripts/delete-commands.js
@@ -1,10 +1,10 @@
 // To be run once.
 
 import { REST } from '@discordjs/rest';
-import { Routes } from 'discord-api-types/v9';
+import { Routes } from 'discord-api-types/v10';
 import { token, applicationId } from '#settings';
 
-const rest = new REST({ version: '9' }).setToken(token);
+const rest = new REST({ version: '10' }).setToken(token);
 
 (async () => {
 	const data = await rest.get(Routes.applicationCommands(applicationId));

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -4,7 +4,7 @@
 
 import { readdirSync } from 'fs';
 import { REST } from '@discordjs/rest';
-import { Routes } from 'discord-api-types/v9';
+import { Routes } from 'discord-api-types/v10';
 import { Collection } from 'discord.js';
 import { token, applicationId } from '#settings';
 import { getAbsoluteFileURL } from '#lib/util/util.js';
@@ -31,7 +31,7 @@ for await (const file of commandFiles) {
 	commands.push(command.default.data.toJSON());
 }
 
-const rest = new REST({ version: '9' }).setToken(token);
+const rest = new REST({ version: '10' }).setToken(token);
 
 try {
 	await rest.put(


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
#434
Updates REST and discord-api-types used to v10 for the following scripts:
`deploy-commands.js`
`delete-commands.js`