### PR TITLE
refactor(command-search): use ReplyHandler#reply

### DIFF
--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,5 +1,5 @@
-import { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, SelectMenuBuilder, ButtonBuilder, ButtonStyle, ChannelType } from 'discord.js';
-import { defaultLocale, colors } from '#settings';
+import { SlashCommandBuilder, ActionRowBuilder, SelectMenuBuilder, ButtonBuilder, ButtonStyle, ChannelType } from 'discord.js';
+import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
 import { getLocale, msToTime, msToTimeString } from '#lib/util/util.js';
 import { data } from '#lib/util/common.js';
@@ -39,16 +39,11 @@ export default {
 			return;
 		}
 
-		await interaction.editReply({
-			embeds: [
-				new EmbedBuilder()
-					.setDescription(tracks.map((track, index) => {
-						const duration = msToTime(track.info.length);
-						const durationString = track.info.isStream ? '∞' : msToTimeString(duration, true);
-						return `\`${(index + 1).toString().padStart(tracks.length.toString().length, ' ')}.\` **[${track.info.title}](${track.info.uri})** \`[${durationString}]\``;
-					}).join('\n'))
-					.setColor(colors.neutral),
-			],
+		await interaction.replyHandler.reply(tracks.map((track, index) => {
+			const duration = msToTime(track.info.length);
+			const durationString = track.info.isStream ? '∞' : msToTimeString(duration, true);
+			return `\`${(index + 1).toString().padStart(tracks.length.toString().length, ' ')}.\` **[${track.info.title}](${track.info.uri})** \`[${durationString}]\``;
+		}).join('\n'), {
 			components: [
 				new ActionRowBuilder()
 					.addComponents(
@@ -73,6 +68,6 @@ export default {
 							.setStyle(ButtonStyle.Danger),
 					),
 			],
-		});
+		}, 'neutral');
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Closes #442
Makes use of `ReplyHandler#reply`. Reduces `commands/search.js`'s imports.