### PR TITLE
feat(command-play): disable feature if spotify credentials are blank

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -129,6 +129,9 @@ export default {
 				DEFAULT: 'Found no results from your query.',
 				SPOTIFY: 'Found no results from your Spotify query.'
 			},
+			DISABLED: {
+				SPOTIFY: 'Spotify feature is currently disabled.'
+			},
 			LOAD_FAILED: 'Failed to load the track.'
 		}
 	},

--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -130,7 +130,7 @@ export default {
 				SPOTIFY: 'Found no results from your Spotify query.'
 			},
 			DISABLED: {
-				SPOTIFY: 'Spotify feature is currently disabled.'
+				SPOTIFY: 'Spotify integration is not configured.'
 			},
 			LOAD_FAILED: 'Failed to load the track.'
 		}

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder, PermissionsBitField, ChannelType } from 'discord.js';
 import { SpotifyItemType } from '@lavaclient/spotify';
-import { defaultLocale } from '#settings';
+import { defaultLocale, spotify } from '#settings';
 import { checks } from '#lib/util/constants.js';
 import { getLocale } from '#lib/util/util.js';
 import { data } from '#lib/util/common.js';
@@ -49,6 +49,10 @@ export default {
 		const query = interaction.options.getString('query'), insert = interaction.options.getBoolean('insert');
 		let tracks = [], msg = '', extras = [];
 		if (interaction.client.music.spotify.isSpotifyUrl(query)) {
+			if (!spotify.client_id || !spotify.client_secret) {
+				await interaction.replyHandler.locale('FEATURE.DISABLED.DEFAULT', {}, 'error');
+				return;
+			}
 			const item = await interaction.client.music.spotify.load(query);
 			switch (item?.type) {
 				case SpotifyItemType.Track: {

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -50,7 +50,7 @@ export default {
 		let tracks = [], msg = '', extras = [];
 		if (interaction.client.music.spotify.isSpotifyUrl(query)) {
 			if (!spotify.client_id || !spotify.client_secret) {
-				await interaction.replyHandler.locale('FEATURE.DISABLED.DEFAULT', {}, 'error');
+				await interaction.replyHandler.locale('CMD.PLAY.RESPONSE.DISABLED.SPOTIFY', {}, 'error');
 				return;
 			}
 			const item = await interaction.client.music.spotify.load(query);


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Closes #444
If the host provided blank spotify credentials in their Quaver instance and a discord user queries a spotify link, sends a locale, informing the discord user that the feature is disabled. While at the same time refraining from resolving the spotify query. 

Otherwise, `interactionCreate` will handle the error if the host provided invalid credentials instead.

