### PR TITLE
fix(command-247): set timeout on 24/7 disable while nothing playing

### DIFF
--- a/src/commands/247.js
+++ b/src/commands/247.js
@@ -52,6 +52,6 @@ export default {
 		// pause timeout is theoretically impossible because the user would need to be in the same vc as Quaver
 		// and pause timeout is only set when everyone leaves
 		await interaction.replyHandler.locale(always ? 'CMD.247.RESPONSE.ENABLED' : 'CMD.247.RESPONSE.DISABLED', { footer: always ? getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'CMD.247.MISC.NOTE') : null });
-		if (!always && !player.playing) { player.queue.emit('finish'); }
+		if (!always && !player.playing) player.queue.emit('finish');
 	},
 };

--- a/src/commands/247.js
+++ b/src/commands/247.js
@@ -52,5 +52,6 @@ export default {
 		// pause timeout is theoretically impossible because the user would need to be in the same vc as Quaver
 		// and pause timeout is only set when everyone leaves
 		await interaction.replyHandler.locale(always ? 'CMD.247.RESPONSE.ENABLED' : 'CMD.247.RESPONSE.DISABLED', { footer: always ? getLocale(await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale, 'CMD.247.MISC.NOTE') : null });
+		if (!always && !player.playing) { player.queue.emit('finish'); }
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Fixes #456
Emits the queueFinish event for the purpose of setting time out when 24/7 is disabled while nothing is playing.