### PR TITLE
feat: use modal for queue pages

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -141,7 +141,12 @@ export default {
 	QUEUE: {
 		DESCRIPTION: 'Show the queue.',
 		RESPONSE: {
-			QUEUE_EMPTY: 'There is nothing coming up.'
+			QUEUE_EMPTY: 'There is nothing coming up.',
+			OUT_OF_RANGE: 'Your input was invalid.'
+		},
+		MISC: {
+			PAGE: 'Page',
+			MODAL_TITLE: 'Go to page',
 		}
 	},
 	REMOVE: {

--- a/locales/en/misc.js
+++ b/locales/en/misc.js
@@ -1,7 +1,7 @@
 export default {
 	PAGE: 'Page %1 of %2',
 	POSITION: 'Position',
-	REFRESH: 'Refresh',
+	GO_TO: 'Go to',
 	CURRENT: 'Current',
 	QUEUE: 'Queue',
 	CANCEL: 'Cancel',

--- a/src/commands/queue.js
+++ b/src/commands/queue.js
@@ -37,15 +37,14 @@ export default {
 								.setDisabled(true)
 								.setStyle(ButtonStyle.Primary),
 							new ButtonBuilder()
+								.setCustomId('queue_goto')
+								.setStyle(ButtonStyle.Secondary)
+								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.GO_TO')),
+							new ButtonBuilder()
 								.setCustomId('queue_2')
 								.setEmoji('➡️')
 								.setDisabled(pages.length === 1)
 								.setStyle(ButtonStyle.Primary),
-							new ButtonBuilder()
-								.setCustomId('queue_1')
-								.setEmoji('🔁')
-								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.REFRESH')),
 						),
 				],
 				ephemeral: true,

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -105,5 +105,19 @@ export default {
 				return interaction.replyHandler.locale('DISCORD.GENERIC_ERROR', { type: 'error' });
 			}
 		}
+		if (interaction.isModalSubmit()) {
+			const modal = interaction.client.modals.get(interaction.customId.split('_')[0]);
+			if (!modal) return;
+			logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Processing modal ${interaction.customId}`, label: 'Quaver' });
+			try {
+				logger.info({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Executing modal ${interaction.customId}`, label: 'Quaver' });
+				return modal.execute(interaction);
+			}
+			catch (err) {
+				logger.error({ message: `[${interaction.guildId ? `G ${interaction.guildId} | ` : ''}U ${interaction.user.id}] Encountered error with modal ${interaction.customId}`, label: 'Quaver' });
+				logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
+				return interaction.replyHandler.locale('DISCORD.GENERIC_ERROR', { type: 'error' });
+			}
+		}
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Updates queue to use a modal to go to pages, and adds the relevant portion to interactionCreate event to handle modals.