### PR TITLE
feat: persist search across pages

### DIFF
--- a/locales/en/misc.js
+++ b/locales/en/misc.js
@@ -13,5 +13,6 @@ export default {
 	LIVE: 'LIVE',
 	STREAMING: 'Streaming',
 	ACTION_IRREVERSIBLE: 'This action is irreversible.',
-	CONFIRM: 'Confirm'
+	CONFIRM: 'Confirm',
+	ADD: 'Add'
 };

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -56,8 +56,8 @@ export default {
 									if (label.length >= 100) label = `${label.substring(0, 97)}...`;
 									return { label: label, description: track.info.author, value: track.info.identifier };
 								}))
-								.setMinValues(1)
-								.setMaxValues(Math.min(pages[0].length, 10)),
+								.setMinValues(0)
+								.setMaxValues(pages[0].length),
 						),
 					new ActionRowBuilder()
 						.addComponents(
@@ -71,6 +71,11 @@ export default {
 								.setEmoji('➡️')
 								.setDisabled(pages.length === 1)
 								.setStyle(ButtonStyle.Primary),
+							new ButtonBuilder()
+								.setCustomId('search_add')
+								.setStyle(ButtonStyle.Success)
+								.setDisabled(true)
+								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.ADD')),
 							new ButtonBuilder()
 								.setCustomId('cancel')
 								.setStyle(ButtonStyle.Secondary)
@@ -92,5 +97,6 @@ export default {
 			);
 			delete searchState[message.id];
 		}, 30 * 1000, msg);
+		searchState[msg.id].selected = [];
 	},
 };

--- a/src/components/buttons/cancel.js
+++ b/src/components/buttons/cancel.js
@@ -1,11 +1,13 @@
-import { confirmationTimeout } from '#lib/util/common.js';
+import { confirmationTimeout, searchState } from '#lib/util/common.js';
 
 export default {
 	name: 'cancel',
 	async execute(interaction) {
 		if (interaction.message.interaction.user.id !== interaction.user.id) return interaction.replyHandler.locale('DISCORD.INTERACTION.USER_MISMATCH', { type: 'error' });
 		clearTimeout(confirmationTimeout[interaction.message.id]);
+		clearTimeout(searchState[interaction.message.id]?.timeout);
 		delete confirmationTimeout[interaction.message.id];
+		delete searchState[interaction.message.id];
 		return interaction.replyHandler.locale('DISCORD.INTERACTION.CANCELED', { args: [interaction.message.interaction.user.id], components: [], force: 'update' });
 	},
 };

--- a/src/components/buttons/search.js
+++ b/src/components/buttons/search.js
@@ -1,6 +1,9 @@
-import { ActionRowBuilder, ButtonBuilder, EmbedBuilder, escapeMarkdown, SelectMenuBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ChannelType, EmbedBuilder, escapeMarkdown, PermissionsBitField, SelectMenuBuilder } from 'discord.js';
 import { getGuildLocale, messageDataBuilder, msToTime, msToTimeString } from '#lib/util/util.js';
 import { searchState } from '#lib/util/common.js';
+import { checks } from '#lib/util/constants.js';
+import PlayerHandler from '#lib/PlayerHandler.js';
+import { features } from '#settings';
 
 export default {
 	name: 'search',
@@ -9,7 +12,72 @@ export default {
 		if (interaction.message.interaction.user.id !== interaction.user.id) return interaction.replyHandler.locale('DISCORD.INTERACTION.USER_MISMATCH', { type: 'error' });
 		const state = searchState[interaction.message.id];
 		if (!state) return interaction.replyHandler.locale('DISCORD.INTERACTION.EXPIRED', { components: [], force: 'update' });
-		const page = parseInt(interaction.customId.split('_')[1]);
+		let page = interaction.customId.split('_')[1];
+		if (page === 'add') {
+			const { bot, io } = await import('#src/main.js');
+			const tracks = state.selected;
+			let player = interaction.client.music.players.get(interaction.guildId);
+			if (!interaction.member?.voice.channelId) return interaction.replyHandler.locale(checks.IN_VOICE, { type: 'error' });
+			if (player && interaction.member?.voice.channelId !== player.channelId) return interaction.replyHandler.locale(checks.IN_SESSION_VOICE, { type: 'error' });
+			// check for connect, speak permission for channel
+			const permissions = interaction.member?.voice.channel.permissionsFor(interaction.client.user.id);
+			if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC', { type: 'error' });
+			if (interaction.member?.voice.channel.type === ChannelType.GuildStageVoice && !permissions.has(PermissionsBitField.StageModerator)) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.STAGE', { type: 'error' });
+			if (interaction.guild.members.me.isCommunicationDisabled()) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.TIMED_OUT', { type: 'error' });
+
+			clearTimeout(state.timeout);
+			await interaction.replyHandler.locale('MISC.LOADING', { components: [], force: 'update' });
+			const resolvedTracks = [];
+			for (const track of tracks) {
+				const results = await interaction.client.music.rest.loadTracks(track);
+				if (results.loadType === 'TRACK_LOADED') resolvedTracks.push(results.tracks[0]);
+			}
+			let msg, extras = [];
+			if (resolvedTracks.length === 1) {
+				msg = 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.DEFAULT';
+				extras = [escapeMarkdown(resolvedTracks[0].info.title), resolvedTracks[0].info.uri];
+			}
+			else {
+				msg = 'MUSIC.QUEUE.TRACK_ADDED.MULTIPLE.DEFAULT';
+				extras = [resolvedTracks.length, await getGuildLocale(interaction.guildId, 'MISC.YOUR_SEARCH'), ''] ;
+			}
+			if (!player?.connected) {
+				player = interaction.client.music.createPlayer(interaction.guildId);
+				player.handler = new PlayerHandler(interaction.client, player);
+				player.queue.channel = interaction.channel;
+				await player.connect(interaction.member.voice.channelId, { deafened: true });
+				// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queuing tracks
+				// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queuing tracks
+				// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
+				const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
+				if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
+					if (interaction.guild) timedOut ? await interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.TIMED_OUT', { type: 'error', components: [] }) : await interaction.replyHandler.locale('DISCORD.INTERACTION.CANCELED', { args: [interaction.user.id], components: [] });
+					return player.handler.disconnect();
+				}
+			}
+
+			const firstPosition = player.queue.tracks.length + 1;
+			const endPosition = firstPosition + resolvedTracks.length - 1;
+			player.queue.add(resolvedTracks, { requester: interaction.user.id });
+
+			const started = player.playing || player.paused;
+			await interaction.replyHandler.reply(
+				new EmbedBuilder()
+					.setDescription(await getGuildLocale(interaction.guildId, msg, ...extras))
+					.setFooter({ text: started ? `${await getGuildLocale(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
+				{ type: 'success', components: [] },
+			);
+			if (!started) await player.queue.start();
+			if (features.web.enabled) {
+				io.to(`guild:${interaction.guildId}`).emit('queueUpdate', player.queue.tracks.map(track => {
+					track.requesterTag = bot.users.cache.get(track.requester)?.tag;
+					return track;
+				}));
+			}
+			delete searchState[interaction.message.id];
+			return;
+		}
+		page = parseInt(page);
 		clearTimeout(state.timeout);
 		state.timeout = setTimeout(async message => {
 			await message.edit(
@@ -36,14 +104,28 @@ export default {
 			.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', page, pages.length) });
 		original.components[0] = ActionRowBuilder.from(original.components[0]);
 		original.components[0].components[0] = SelectMenuBuilder.from(original.components[0].components[0])
-			.setOptions(pages[page - 1].map((track, index) => {
-				let label = `${firstIndex + index}. ${track.info.title}`;
-				if (label.length >= 100) {
-					label = `${label.substring(0, 97)}...`;
-				}
-				return { label: label, description: track.info.author, value: track.info.identifier };
-			}))
-			.setMaxValues(Math.min(pages[page - 1].length, 10)),
+			.setOptions(
+				pages[page - 1]
+					.map((track, index) => {
+						let label = `${firstIndex + index}. ${track.info.title}`;
+						if (label.length >= 100) label = `${label.substring(0, 97)}...`;
+						return { label: label, description: track.info.author, value: track.info.identifier, default: !!state.selected.find(identifier => identifier === track.info.identifier) };
+					})
+					.concat(
+						state.selected
+							.map(identifier => {
+								const refPg = pages.indexOf(pages.find(pg => pg.find(t => t.info.identifier === identifier)));
+								const firstIdx = 10 * refPg + 1;
+								const refTrack = pages[refPg].find(t => t.info.identifier === identifier);
+								let label = `${firstIdx + pages[refPg].indexOf(refTrack)}. ${refTrack.info.title}`;
+								if (label.length >= 100) label = `${label.substring(0, 97)}...`;
+								return { label: label, description: refTrack.info.author, value: identifier, default: true };
+							})
+							.filter(options => !pages[page - 1].find(track => track.info.identifier === options.value)),
+					)
+					.sort((a, b) => parseInt(a.label.split('.')[0]) - parseInt(b.label.split('.')[0])),
+			);
+		original.components[0].components[0].setMaxValues(original.components[0].components[0].options.length);
 		original.components[1] = ActionRowBuilder.from(original.components[1]);
 		original.components[1].components[0] = ButtonBuilder.from(original.components[1].components[0])
 			.setCustomId(`search_${page - 1}`)

--- a/src/components/selectmenus/search.js
+++ b/src/components/selectmenus/search.js
@@ -1,8 +1,5 @@
-import { PermissionsBitField, ChannelType, EmbedBuilder, escapeMarkdown } from 'discord.js';
-import { features } from '#settings';
-import { getGuildLocale } from '#lib/util/util.js';
-import { checks } from '#lib/util/constants.js';
-import PlayerHandler from '#lib/PlayerHandler.js';
+import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, SelectMenuBuilder } from 'discord.js';
+import { getGuildLocale, messageDataBuilder } from '#lib/util/util.js';
 import { searchState } from '#lib/util/common.js';
 
 export default {
@@ -11,68 +8,46 @@ export default {
 	async execute(interaction) {
 		if (interaction.message.interaction.user.id !== interaction.user.id) return interaction.replyHandler.locale('DISCORD.INTERACTION.USER_MISMATCH', { type: 'error' });
 		const state = searchState[interaction.message.id];
-		if (state) {
-			clearTimeout(state.timeout);
-			delete searchState[interaction.message.id];
-		}
-		const { bot, io } = await import('#src/main.js');
-		const tracks = interaction.values;
-		let player = interaction.client.music.players.get(interaction.guildId);
-		if (!interaction.member?.voice.channelId) return interaction.replyHandler.locale(checks.IN_VOICE, { type: 'error' });
-		if (player && interaction.member?.voice.channelId !== player.channelId) return interaction.replyHandler.locale(checks.IN_SESSION_VOICE, { type: 'error' });
-		// check for connect, speak permission for channel
-		const permissions = interaction.member?.voice.channel.permissionsFor(interaction.client.user.id);
-		if (!permissions.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC', { type: 'error' });
-		if (interaction.member?.voice.channel.type === ChannelType.GuildStageVoice && !permissions.has(PermissionsBitField.StageModerator)) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.STAGE', { type: 'error' });
-		if (interaction.guild.members.me.isCommunicationDisabled()) return interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.TIMED_OUT', { type: 'error' });
-
-		await interaction.replyHandler.locale('MISC.LOADING', { components: [], force: 'update' });
-		const resolvedTracks = [];
-		for (const track of tracks) {
-			const results = await interaction.client.music.rest.loadTracks(track);
-			if (results.loadType === 'TRACK_LOADED') resolvedTracks.push(results.tracks[0]);
-		}
-		let msg, extras = [];
-		if (resolvedTracks.length === 1) {
-			msg = 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.DEFAULT';
-			extras = [escapeMarkdown(resolvedTracks[0].info.title), resolvedTracks[0].info.uri];
-		}
-		else {
-			msg = 'MUSIC.QUEUE.TRACK_ADDED.MULTIPLE.DEFAULT';
-			extras = [resolvedTracks.length, await getGuildLocale(interaction.guildId, 'MISC.YOUR_SEARCH'), ''] ;
-		}
-		if (!player?.connected) {
-			player = interaction.client.music.createPlayer(interaction.guildId);
-			player.handler = new PlayerHandler(interaction.client, player);
-			player.queue.channel = interaction.channel;
-			await player.connect(interaction.member.voice.channelId, { deafened: true });
-			// Ensure that Quaver destroys the player if the user leaves the channel while Quaver is queuing tracks
-			// Ensure that Quaver destroys the player if Quaver gets timed out by the user while Quaver is queuing tracks
-			// Ensure that Quaver destroys the player if Quaver gets kicked or banned by the user while Quaver is queuing tracks
-			const timedOut = interaction.guild?.members.me.isCommunicationDisabled();
-			if (!interaction.member.voice.channelId || timedOut || !interaction.guild) {
-				if (interaction.guild) timedOut ? await interaction.replyHandler.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.TIMED_OUT', { type: 'error', components: [] }) : await interaction.replyHandler.locale('DISCORD.INTERACTION.CANCELED', { args: [interaction.user.id], components: [] });
-				return player.handler.disconnect();
-			}
-		}
-
-		const firstPosition = player.queue.tracks.length + 1;
-		const endPosition = firstPosition + resolvedTracks.length - 1;
-		player.queue.add(resolvedTracks, { requester: interaction.user.id });
-
-		const started = player.playing || player.paused;
-		await interaction.replyHandler.reply(
-			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, msg, ...extras))
-				.setFooter({ text: started ? `${await getGuildLocale(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
-			{ type: 'success', components: [] },
+		if (!state) return interaction.replyHandler.locale('DISCORD.INTERACTION.EXPIRED', { components: [], force: 'update' });
+		clearTimeout(state.timeout);
+		state.timeout = setTimeout(async message => {
+			await message.edit(
+				messageDataBuilder(
+					new EmbedBuilder()
+						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+					{ components: [] },
+				),
+			);
+			delete searchState[message.id];
+		}, 30 * 1000, interaction.message);
+		state.selected = interaction.values;
+		const pages = state.pages;
+		const original = { embeds: interaction.message.embeds, components: interaction.message.components };
+		if (original.embeds.length === 0) return interaction.message.delete();
+		original.components[0] = ActionRowBuilder.from(original.components[0]);
+		original.components[0].components[0] = SelectMenuBuilder.from(original.components[0].components[0]);
+		original.components[0].components[0].setOptions(
+			original.components[0].components[0].options
+				.map(data => {
+					data = data.data;
+					return { label: data.label, description: data.description, value: data.value, default: !!state.selected.find(identifier => identifier === data.value) };
+				})
+				.concat(
+					state.selected
+						.map(identifier => {
+							const refPg = pages.indexOf(pages.find(pg => pg.find(t => t.info.identifier === identifier)));
+							const firstIdx = 10 * refPg + 1;
+							const refTrack = pages[refPg].find(t => t.info.identifier === identifier);
+							let label = `${firstIdx + pages[refPg].indexOf(refTrack)}. ${refTrack.info.title}`;
+							if (label.length >= 100) label = `${label.substring(0, 97)}...`;
+							return { label: label, description: refTrack.info.author, value: identifier, default: true };
+						})
+						.filter(options => !original.components[0].components[0].options.find(opt => opt.data.value === options.value)),
+				)
+				.sort((a, b) => parseInt(a.label.split('.')[0]) - parseInt(b.label.split('.')[0])),
 		);
-		if (!started) await player.queue.start();
-		if (features.web.enabled) {
-			io.to(`guild:${interaction.guildId}`).emit('queueUpdate', player.queue.tracks.map(track => {
-				track.requesterTag = bot.users.cache.get(track.requester)?.tag;
-				return track;
-			}));
-		}
+		original.components[1].components[2] = ButtonBuilder.from(original.components[1].components[2])
+			.setDisabled(state.selected.length === 0);
+		return interaction.replyHandler.reply(original.embeds, { components: original.components, force: 'update' });
 	},
 };


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Adds an Add button to the search command, allowing the user to add tracks between pages.