### PR TITLE
refactor: append String to getLocale and getGuildLocale's names

### DIFF
--- a/lib/PlayerHandler.js
+++ b/lib/PlayerHandler.js
@@ -1,7 +1,7 @@
 import { PermissionsBitField, ChannelType } from 'discord.js';
 import { features } from '#settings';
 import { logger } from '#lib/util/common.js';
-import { getGuildLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, messageDataBuilder } from '#lib/util/util.js';
 
 /** Class for handling Lavaclient's Player. */
 export default class PlayerHandler {
@@ -32,7 +32,7 @@ export default class PlayerHandler {
 		if (!permissions?.has(new PermissionsBitField([PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.Connect, PermissionsBitField.Flags.Speak]))) return;
 		if (!permissions?.has(PermissionsBitField.StageModerator)) return;
 		if (this.client.guilds.cache.get(this.player.guildId)?.members.me.isCommunicationDisabled()) return;
-		if (voiceChannel.stageInstance?.topic !== await getGuildLocale(this.player.guildId, 'MISC.STAGE_TOPIC')) return;
+		if (voiceChannel.stageInstance?.topic !== await getGuildLocaleString(this.player.guildId, 'MISC.STAGE_TOPIC')) return;
 		try {
 			await voiceChannel.stageInstance.delete();
 		}
@@ -70,6 +70,6 @@ export default class PlayerHandler {
 	 * @returns {Promise<import('discord.js').Message>|false} The message that was sent.
 	 */
 	async locale(code, { args = [], type = 'neutral', components = null, files = null } = {}) {
-		return this.send(await getGuildLocale(this.player.guildId, code, ...args), { type, components, files });
+		return this.send(await getGuildLocaleString(this.player.guildId, code, ...args), { type, components, files });
 	}
 }

--- a/lib/ReplyHandler.js
+++ b/lib/ReplyHandler.js
@@ -1,6 +1,6 @@
 import { PermissionsBitField } from 'discord.js';
 import { logger } from '#lib/util/common.js';
-import { getGuildLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, messageDataBuilder } from '#lib/util/util.js';
 
 /** Class for handling replies to interactions. */
 export default class ReplyHandler {
@@ -59,6 +59,6 @@ export default class ReplyHandler {
 	 * @returns {Promise<import('discord.js').InteractionResponse|import('discord.js').Message|boolean>} The message that was sent.
 	 */
 	async locale(code, { args = [], type = 'neutral', components = null, files = null, ephemeral = false, force = null } = {}) {
-		return this.reply(await getGuildLocale(this.interaction.guildId, code, ...args), { type, components, files, ephemeral, force });
+		return this.reply(await getGuildLocaleString(this.interaction.guildId, code, ...args), { type, components, files, ephemeral, force });
 	}
 }

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -47,7 +47,7 @@ export function msToTime(milliseconds, format) {
 export function msToTimeString(msObject, simple) {
 	if (simple) {
 		if (msObject['d'] > 0) {
-			return getLocale(defaultLocale, 'MISC.MORE_THAN_A_DAY');
+			return getLocaleString(defaultLocale, 'MISC.MORE_THAN_A_DAY');
 		}
 		return `${msObject['h'] > 0 ? `${msObject['h']}:` : ''}${msObject['h'] > 0 ? msObject['m'].toString().padStart(2, '0') : msObject['m']}:${msObject['s'].toString().padStart(2, '0')}`;
 	}
@@ -136,7 +136,7 @@ export function paginate(arr, size) {
  * @param {...string} vars The extra variables required in some localized strings.
  * @returns {string|'LOCALE_MISSING'|'STRING_MISSING'} The localized string, or LOCALE_MISSING if the locale is missing, or STRING_MISSING if the string is missing.
  */
-export function getLocale(language, string, ...vars) {
+export function getLocaleString(language, string, ...vars) {
 	if (!locales.get(language)) return 'LOCALE_MISSING';
 	let strings = locales.get(language);
 	let locale = get(strings, string);
@@ -160,8 +160,8 @@ export function getLocale(language, string, ...vars) {
  * @param {...string} vars The extra variables required in some localized strings.
  * @returns {Promise<string|'LOCALE_MISSING'|'STRING_MISSING'>} The localized string, or LOCALE_MISSING if the locale is missing, or STRING_MISSING if the string is missing.
  */
-export async function getGuildLocale(guildId, string, ...vars) {
-	return getLocale(await data.guild.get(guildId, 'settings.locale') ?? defaultLocale, string, ...vars);
+export async function getGuildLocaleString(guildId, string, ...vars) {
+	return getLocaleString(await data.guild.get(guildId, 'settings.locale') ?? defaultLocale, string, ...vars);
 }
 
 /**
@@ -255,31 +255,31 @@ export async function settingsPage(interaction, guildLocale, option) {
 			actionRow.addComponents(
 				new ButtonBuilder()
 					.setCustomId('format_simple')
-					.setLabel(getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.OPTIONS.SIMPLE'))
+					.setLabel(getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.OPTIONS.SIMPLE'))
 					.setStyle(current === 'simple' ? ButtonStyle.Success : ButtonStyle.Secondary)
 					.setDisabled(current === 'simple'),
 				new ButtonBuilder()
 					.setCustomId('format_detailed')
-					.setLabel(getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.OPTIONS.DETAILED'))
+					.setLabel(getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.OPTIONS.DETAILED'))
 					.setStyle(current === 'detailed' ? ButtonStyle.Success : ButtonStyle.Secondary)
 					.setDisabled(current === 'detailed'),
 			);
 			embeds = current === 'simple' ? [
 				new EmbedBuilder()
-					.setDescription(`${getLocale(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE', escapeMarkdown(getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE')), 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', '4:20')}\n${getLocale(guildLocale, 'MISC.ADDED_BY', interaction.user.id)}`)
+					.setDescription(`${getLocaleString(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE', escapeMarkdown(getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE')), 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', '4:20')}\n${getLocaleString(guildLocale, 'MISC.ADDED_BY', interaction.user.id)}`)
 					.setColor(colors.neutral),
 			] : [
 				new EmbedBuilder()
-					.setTitle(getLocale(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.TITLE'))
-					.setDescription(`**[${escapeMarkdown(getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.DETAILED'))}](https://www.youtube.com/watch?v=dQw4w9WgXcQ)**`)
+					.setTitle(getLocaleString(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.TITLE'))
+					.setDescription(`**[${escapeMarkdown(getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.DETAILED'))}](https://www.youtube.com/watch?v=dQw4w9WgXcQ)**`)
 					.addFields([
-						{ name: getLocale(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.DURATION'), value: '`4:20`', inline: true },
-						{ name: getLocale(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.UPLOADER'), value: 'Rick Astley', inline: true },
-						{ name: getLocale(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.ADDED_BY'), value: `<@${interaction.user.id}>`, inline: true },
+						{ name: getLocaleString(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.DURATION'), value: '`4:20`', inline: true },
+						{ name: getLocaleString(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.UPLOADER'), value: 'Rick Astley', inline: true },
+						{ name: getLocaleString(guildLocale, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.ADDED_BY'), value: `<@${interaction.user.id}>`, inline: true },
 					])
 					.setThumbnail('https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg'),
 			];
-			current = getLocale(guildLocale, `CMD.SETTINGS.MISC.FORMAT.OPTIONS.${current.toUpperCase()}`);
+			current = getLocaleString(guildLocale, `CMD.SETTINGS.MISC.FORMAT.OPTIONS.${current.toUpperCase()}`);
 		}
 	}
 	return { current, embeds, actionRow };

--- a/src/commands/247.js
+++ b/src/commands/247.js
@@ -1,17 +1,17 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 import { data } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('247')
-		.setDescription(getLocale(defaultLocale, 'CMD.247.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.247.DESCRIPTION'))
 		.addBooleanOption(option =>
 			option
 				.setName('enabled')
-				.setDescription(getLocale(defaultLocale, 'CMD.247.OPTION.ENABLED'))),
+				.setDescription(getLocaleString(defaultLocale, 'CMD.247.OPTION.ENABLED'))),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -40,8 +40,8 @@ export default {
 		// and pause timeout is only set when everyone leaves
 		await interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, always ? 'CMD.247.RESPONSE.ENABLED' : 'CMD.247.RESPONSE.DISABLED'))
-				.setFooter({ text: always ? await getGuildLocale(interaction.guildId, 'CMD.247.MISC.NOTE') : null }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, always ? 'CMD.247.RESPONSE.ENABLED' : 'CMD.247.RESPONSE.DISABLED'))
+				.setFooter({ text: always ? await getGuildLocaleString(interaction.guildId, 'CMD.247.MISC.NOTE') : null }),
 		);
 		if (!always && !player.playing) player.queue.emit('finish');
 	},

--- a/src/commands/bassboost.js
+++ b/src/commands/bassboost.js
@@ -1,16 +1,16 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('bassboost')
-		.setDescription(getLocale(defaultLocale, 'CMD.BASSBOOST.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.BASSBOOST.DESCRIPTION'))
 		.addBooleanOption(option =>
 			option
 				.setName('enabled')
-				.setDescription(getLocale(defaultLocale, 'CMD.BASSBOOST.OPTION.ENABLED'))),
+				.setDescription(getLocaleString(defaultLocale, 'CMD.BASSBOOST.OPTION.ENABLED'))),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -29,8 +29,8 @@ export default {
 		if (features.web.enabled) io.to(`guild:${interaction.guildId}`).emit('filterUpdate', { bassboost: player.bassboost, nightcore: player.nightcore });
 		return interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, player.bassboost ? 'CMD.BASSBOOST.RESPONSE.ENABLED' : 'CMD.BASSBOOST.RESPONSE.DISABLED'))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, player.bassboost ? 'CMD.BASSBOOST.RESPONSE.ENABLED' : 'CMD.BASSBOOST.RESPONSE.DISABLED'))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
 		);
 	},
 };

--- a/src/commands/bind.js
+++ b/src/commands/bind.js
@@ -1,17 +1,17 @@
 import { SlashCommandBuilder, ChannelType, PermissionsBitField } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 import { data } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('bind')
-		.setDescription(getLocale(defaultLocale, 'CMD.BIND.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.BIND.DESCRIPTION'))
 		.addChannelOption(option =>
 			option
 				.setName('new_channel')
-				.setDescription(getLocale(defaultLocale, 'CMD.BIND.OPTION.NEW_CHANNEL'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.BIND.OPTION.NEW_CHANNEL'))
 				.addChannelTypes(ChannelType.GuildText, ChannelType.GuildVoice)
 				.setRequired(true)),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],

--- a/src/commands/clear.js
+++ b/src/commands/clear.js
@@ -1,13 +1,13 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder } from '#lib/util/util.js';
 import { confirmationTimeout } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('clear')
-		.setDescription(getLocale(defaultLocale, 'CMD.CLEAR.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.CLEAR.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -19,8 +19,8 @@ export default {
 		if (player.queue.tracks.length === 0) return interaction.replyHandler.locale('CMD.CLEAR.RESPONSE.QUEUE_EMPTY', { type: 'error' });
 		const msg = await interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.CLEAR.RESPONSE.CONFIRMATION'))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.CLEAR.RESPONSE.CONFIRMATION'))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
 			{
 				type: 'warning',
 				components: [
@@ -29,11 +29,11 @@ export default {
 							new ButtonBuilder()
 								.setCustomId('clear')
 								.setStyle(ButtonStyle.Danger)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CONFIRM')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CONFIRM')),
 							new ButtonBuilder()
 								.setCustomId('cancel')
 								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CANCEL')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CANCEL')),
 						),
 				],
 				fetchReply: true,
@@ -43,7 +43,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/commands/disconnect.js
+++ b/src/commands/disconnect.js
@@ -1,13 +1,13 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder } from '#lib/util/util.js';
 import { confirmationTimeout, data } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('disconnect')
-		.setDescription(getLocale(defaultLocale, 'CMD.DISCONNECT.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.DISCONNECT.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -23,8 +23,8 @@ export default {
 		}
 		const msg = await interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.DISCONNECT.RESPONSE.CONFIRMATION'))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.DISCONNECT.RESPONSE.CONFIRMATION'))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
 			{
 				type: 'warning',
 				components: [
@@ -33,11 +33,11 @@ export default {
 							new ButtonBuilder()
 								.setCustomId('disconnect')
 								.setStyle(ButtonStyle.Danger)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CONFIRM')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CONFIRM')),
 							new ButtonBuilder()
 								.setCustomId('cancel')
 								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CANCEL')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CANCEL')),
 						),
 				],
 				fetchReply: true,
@@ -47,7 +47,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -1,12 +1,12 @@
 import { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } from 'discord.js';
 import { version } from '#lib/util/version.js';
 import { defaultLocale } from '#settings';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('info')
-		.setDescription(getLocale(defaultLocale, 'CMD.INFO.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.INFO.DESCRIPTION')),
 	checks: [],
 	permissions: {
 		user: [],
@@ -17,7 +17,7 @@ export default {
 		return interaction.replyHandler.reply(
 			new EmbedBuilder()
 				.setTitle('Quaver')
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.INFO.RESPONSE.SUCCESS', interaction.client.generateInvite({ permissions: [PermissionsBitField.Flags.Administrator], scopes: ['bot', 'applications.commands'] }), version))
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.INFO.RESPONSE.SUCCESS', interaction.client.generateInvite({ permissions: [PermissionsBitField.Flags.Administrator], scopes: ['bot', 'applications.commands'] }), version))
 				.setThumbnail(interaction.client.user.displayAvatarURL({ format: 'png' })),
 			{ ephemeral: true },
 		);

--- a/src/commands/loop.js
+++ b/src/commands/loop.js
@@ -2,21 +2,21 @@ import { SlashCommandBuilder } from 'discord.js';
 import { LoopType } from '@lavaclient/queue';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('loop')
-		.setDescription(getLocale(defaultLocale, 'CMD.LOOP.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.LOOP.DESCRIPTION'))
 		.addStringOption(option =>
 			option
 				.setName('type')
-				.setDescription(getLocale(defaultLocale, 'CMD.LOOP.OPTION.TYPE.DESCRIPTION'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.LOOP.OPTION.TYPE.DESCRIPTION'))
 				.setRequired(true)
 				.addChoices(
-					{ name: getLocale(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.DISABLED'), value: 'disabled' },
-					{ name: getLocale(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.TRACK'), value: 'track' },
-					{ name: getLocale(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.QUEUE'), value: 'queue' },
+					{ name: getLocaleString(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.DISABLED'), value: 'disabled' },
+					{ name: getLocaleString(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.TRACK'), value: 'track' },
+					{ name: getLocaleString(defaultLocale, 'CMD.LOOP.OPTION.TYPE.OPTION.QUEUE'), value: 'queue' },
 				)),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
@@ -32,15 +32,15 @@ export default {
 		switch (type) {
 			case 'disabled':
 				loop = LoopType.None;
-				typeLocale = await getGuildLocale(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.DISABLED');
+				typeLocale = await getGuildLocaleString(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.DISABLED');
 				break;
 			case 'track':
 				loop = LoopType.Song;
-				typeLocale = await getGuildLocale(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.TRACK');
+				typeLocale = await getGuildLocaleString(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.TRACK');
 				break;
 			case 'queue':
 				loop = LoopType.Queue;
-				typeLocale = await getGuildLocale(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.QUEUE');
+				typeLocale = await getGuildLocaleString(interaction.guildId, 'CMD.LOOP.OPTION.TYPE.OPTION.QUEUE');
 				break;
 		}
 		typeLocale = typeLocale.toLowerCase();

--- a/src/commands/move.js
+++ b/src/commands/move.js
@@ -1,23 +1,23 @@
 import { escapeMarkdown, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('move')
-		.setDescription(getLocale(defaultLocale, 'CMD.MOVE.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.MOVE.DESCRIPTION'))
 		.addIntegerOption(option =>
 			option
 				.setName('old_position')
-				.setDescription(getLocale(defaultLocale, 'CMD.MOVE.OPTION.OLD_POSITION'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.MOVE.OPTION.OLD_POSITION'))
 				.setMinValue(1)
 				.setRequired(true)
 				.setAutocomplete(true))
 		.addIntegerOption(option =>
 			option
 				.setName('new_position')
-				.setDescription(getLocale(defaultLocale, 'CMD.MOVE.OPTION.NEW_POSITION'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.MOVE.OPTION.NEW_POSITION'))
 				.setMinValue(1)
 				.setRequired(true)),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],

--- a/src/commands/nightcore.js
+++ b/src/commands/nightcore.js
@@ -1,16 +1,16 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('nightcore')
-		.setDescription(getLocale(defaultLocale, 'CMD.NIGHTCORE.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.NIGHTCORE.DESCRIPTION'))
 		.addBooleanOption(option =>
 			option
 				.setName('enabled')
-				.setDescription(getLocale(defaultLocale, 'CMD.NIGHTCORE.OPTION.ENABLED'))),
+				.setDescription(getLocaleString(defaultLocale, 'CMD.NIGHTCORE.OPTION.ENABLED'))),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -28,8 +28,8 @@ export default {
 		if (features.web.enabled) io.to(`guild:${interaction.guildId}`).emit('filterUpdate', { bassboost: player.bassboost, nightcore: player.nightcore });
 		return interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, player.nightcore ? 'CMD.NIGHTCORE.RESPONSE.ENABLED' : 'CMD.NIGHTCORE.RESPONSE.DISABLED'))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, player.nightcore ? 'CMD.NIGHTCORE.RESPONSE.ENABLED' : 'CMD.NIGHTCORE.RESPONSE.DISABLED'))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
 		);
 	},
 };

--- a/src/commands/pause.js
+++ b/src/commands/pause.js
@@ -1,12 +1,12 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('pause')
-		.setDescription(getLocale(defaultLocale, 'CMD.PAUSE.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.PAUSE.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,11 +1,11 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
-import { msToTime, msToTimeString, getLocale, getGuildLocale } from '#lib/util/util.js';
+import { msToTime, msToTimeString, getLocaleString, getGuildLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('ping')
-		.setDescription(getLocale(defaultLocale, 'CMD.PING.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.PING.DESCRIPTION')),
 	checks: [],
 	permissions: {
 		user: [],
@@ -17,8 +17,8 @@ export default {
 		const uptimeString = msToTimeString(uptime);
 		return interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.PING.RESPONSE.SUCCESS', interaction.guild ? ` ${interaction.guild.shard.ping}ms` : ''))
-				.setFooter({ text: `${await getGuildLocale(interaction.guildId, 'CMD.PING.MISC.UPTIME')} ${uptimeString}` }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.PING.RESPONSE.SUCCESS', interaction.guild ? ` ${interaction.guild.shard.ping}ms` : ''))
+				.setFooter({ text: `${await getGuildLocaleString(interaction.guildId, 'CMD.PING.MISC.UPTIME')} ${uptimeString}` }),
 			{ ephemeral: true },
 		);
 	},

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -2,23 +2,23 @@ import { SlashCommandBuilder, PermissionsBitField, ChannelType, EmbedBuilder, es
 import { SpotifyItemType } from '@lavaclient/spotify';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 import PlayerHandler from '#lib/PlayerHandler.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('play')
-		.setDescription(getLocale(defaultLocale, 'CMD.PLAY.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.PLAY.DESCRIPTION'))
 		.addStringOption(option =>
 			option
 				.setName('query')
-				.setDescription(getLocale(defaultLocale, 'CMD.PLAY.OPTION.QUERY'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.PLAY.OPTION.QUERY'))
 				.setRequired(true)
 				.setAutocomplete(true))
 		.addBooleanOption(option =>
 			option
 				.setName('insert')
-				.setDescription(getLocale(defaultLocale, 'CMD.PLAY.OPTION.INSERT'))),
+				.setDescription(getLocaleString(defaultLocale, 'CMD.PLAY.OPTION.INSERT'))),
 	checks: [checks.GUILD_ONLY, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -109,8 +109,8 @@ export default {
 		const started = player.playing || player.paused;
 		await interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, msg, ...extras))
-				.setFooter({ text: started ? `${await getGuildLocale(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, msg, ...extras))
+				.setFooter({ text: started ? `${await getGuildLocaleString(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
 			{ type: 'success', ephemeral: true },
 		);
 		if (!started) await player.queue.start();

--- a/src/commands/playing.js
+++ b/src/commands/playing.js
@@ -2,12 +2,12 @@ import { escapeMarkdown, SlashCommandBuilder } from 'discord.js';
 import { LoopType } from '@lavaclient/queue';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getBar, getGuildLocale, getLocale, msToTime, msToTimeString } from '#lib/util/util.js';
+import { getBar, getGuildLocaleString, getLocaleString, msToTime, msToTimeString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('playing')
-		.setDescription(getLocale(defaultLocale, 'CMD.PLAYING.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.PLAYING.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -24,7 +24,7 @@ export default {
 		const elapsedString = msToTimeString(elapsed, true);
 		const duration = msToTime(player.queue.current.length);
 		const durationString = msToTimeString(duration, true);
-		if (player.queue.current.isStream) return interaction.replyHandler.reply(`**[${escapeMarkdown(player.queue.current.title)}](${player.queue.current.uri})**\n🔴 **${await getGuildLocale(interaction.guildId, 'MISC.LIVE')}** ${'▬'.repeat(10)}${player.paused ? ' ⏸️' : ''}${player.queue.loop.type !== LoopType.None ? ` ${player.queue.loop.type === LoopType.Queue ? '🔁' : '🔂'}` : ''}${player.bassboost ? ' 🅱️' : ''}\n\`[${await getGuildLocale(interaction.guildId, 'MISC.STREAMING')}]\` | ${await getGuildLocale(interaction.guildId, 'MISC.ADDED_BY', player.queue.current.requester)}`, { ephemeral: true });
-		return interaction.replyHandler.reply(`**[${escapeMarkdown(player.queue.current.title)}](${player.queue.current.uri})**\n${bar}${player.paused ? ' ⏸️' : ''}${player.queue.loop.type !== LoopType.None ? ` ${player.queue.loop.type === LoopType.Queue ? '🔁' : '🔂'}` : ''}${player.bassboost ? ' 🅱️' : ''}${player.nightcore ? ' 🇳' : ''}\n\`[${elapsedString} / ${durationString}]\` | ${await getGuildLocale(interaction.guildId, 'MISC.ADDED_BY', player.queue.current.requester)}`, { ephemeral: true });
+		if (player.queue.current.isStream) return interaction.replyHandler.reply(`**[${escapeMarkdown(player.queue.current.title)}](${player.queue.current.uri})**\n🔴 **${await getGuildLocaleString(interaction.guildId, 'MISC.LIVE')}** ${'▬'.repeat(10)}${player.paused ? ' ⏸️' : ''}${player.queue.loop.type !== LoopType.None ? ` ${player.queue.loop.type === LoopType.Queue ? '🔁' : '🔂'}` : ''}${player.bassboost ? ' 🅱️' : ''}\n\`[${await getGuildLocaleString(interaction.guildId, 'MISC.STREAMING')}]\` | ${await getGuildLocaleString(interaction.guildId, 'MISC.ADDED_BY', player.queue.current.requester)}`, { ephemeral: true });
+		return interaction.replyHandler.reply(`**[${escapeMarkdown(player.queue.current.title)}](${player.queue.current.uri})**\n${bar}${player.paused ? ' ⏸️' : ''}${player.queue.loop.type !== LoopType.None ? ` ${player.queue.loop.type === LoopType.Queue ? '🔁' : '🔂'}` : ''}${player.bassboost ? ' 🅱️' : ''}${player.nightcore ? ' 🇳' : ''}\n\`[${elapsedString} / ${durationString}]\` | ${await getGuildLocaleString(interaction.guildId, 'MISC.ADDED_BY', player.queue.current.requester)}`, { ephemeral: true });
 	},
 };

--- a/src/commands/queue.js
+++ b/src/commands/queue.js
@@ -1,12 +1,12 @@
 import { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, escapeMarkdown } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { paginate, getLocale, msToTime, msToTimeString, getGuildLocale } from '#lib/util/util.js';
+import { paginate, getLocaleString, msToTime, msToTimeString, getGuildLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('queue')
-		.setDescription(getLocale(defaultLocale, 'CMD.QUEUE.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.QUEUE.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -26,7 +26,7 @@ export default {
 						return `\`${index + 1}.\` **[${escapeMarkdown(track.title)}](${track.uri})** \`[${durationString}]\` <@${track.requester}>`;
 					}).join('\n'),
 				)
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', '1', pages.length) }),
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.PAGE', '1', pages.length) }),
 			{
 				components: [
 					new ActionRowBuilder()
@@ -39,7 +39,7 @@ export default {
 							new ButtonBuilder()
 								.setCustomId('queue_goto')
 								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.GO_TO')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.GO_TO')),
 							new ButtonBuilder()
 								.setCustomId('queue_2')
 								.setEmoji('➡️')

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,16 +1,16 @@
 import { escapeMarkdown, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('remove')
-		.setDescription(getLocale(defaultLocale, 'CMD.REMOVE.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.REMOVE.DESCRIPTION'))
 		.addIntegerOption(option =>
 			option
 				.setName('position')
-				.setDescription(getLocale(defaultLocale, 'CMD.REMOVE.OPTION.POSITION'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.REMOVE.OPTION.POSITION'))
 				.setMinValue(1)
 				.setRequired(true)
 				.setAutocomplete(true)),

--- a/src/commands/resume.js
+++ b/src/commands/resume.js
@@ -1,12 +1,12 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('resume')
-		.setDescription(getLocale(defaultLocale, 'CMD.RESUME.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.RESUME.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder, ActionRowBuilder, SelectMenuBuilder, ChannelType, EmbedBuilder, ButtonBuilder, ButtonStyle, escapeMarkdown } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale, messageDataBuilder, msToTime, msToTimeString, paginate } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder, msToTime, msToTimeString, paginate } from '#lib/util/util.js';
 import { searchState } from '#lib/util/common.js';
 
 // credit: https://github.com/lavaclient/djs-v13-example/blob/main/src/commands/Play.ts
@@ -9,11 +9,11 @@ import { searchState } from '#lib/util/common.js';
 export default {
 	data: new SlashCommandBuilder()
 		.setName('search')
-		.setDescription(getLocale(defaultLocale, 'CMD.SEARCH.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.SEARCH.DESCRIPTION'))
 		.addStringOption(option =>
 			option
 				.setName('query')
-				.setDescription(getLocale(defaultLocale, 'CMD.SEARCH.OPTION.QUERY'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.SEARCH.OPTION.QUERY'))
 				.setRequired(true)
 				.setAutocomplete(true)),
 	checks: [checks.GUILD_ONLY],
@@ -43,14 +43,14 @@ export default {
 						return `\`${(index + 1).toString().padStart(tracks.length.toString().length, ' ')}.\` **[${escapeMarkdown(track.info.title)}](${track.info.uri})** \`[${durationString}]\``;
 					}).join('\n'),
 				)
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', '1', pages.length) }),
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.PAGE', '1', pages.length) }),
 			{
 				components: [
 					new ActionRowBuilder()
 						.addComponents(
 							new SelectMenuBuilder()
 								.setCustomId('search')
-								.setPlaceholder(await getGuildLocale(interaction.guildId, 'CMD.SEARCH.MISC.PICK'))
+								.setPlaceholder(await getGuildLocaleString(interaction.guildId, 'CMD.SEARCH.MISC.PICK'))
 								.addOptions(pages[0].map((track, index) => {
 									let label = `${index + 1}. ${track.info.title}`;
 									if (label.length >= 100) label = `${label.substring(0, 97)}...`;
@@ -75,11 +75,11 @@ export default {
 								.setCustomId('search_add')
 								.setStyle(ButtonStyle.Success)
 								.setDisabled(true)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.ADD')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.ADD')),
 							new ButtonBuilder()
 								.setCustomId('cancel')
 								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CANCEL')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CANCEL')),
 						),
 				],
 				fetchReply: true,
@@ -91,7 +91,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/commands/seek.js
+++ b/src/commands/seek.js
@@ -1,28 +1,28 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale, msToTime, msToTimeString } from '#lib/util/util.js';
+import { getLocaleString, msToTime, msToTimeString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('seek')
-		.setDescription(getLocale(defaultLocale, 'CMD.SEEK.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.SEEK.DESCRIPTION'))
 		.addIntegerOption(option =>
 			option
 				.setName('hours')
-				.setDescription(getLocale(defaultLocale, 'CMD.SEEK.OPTION.HOURS'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.SEEK.OPTION.HOURS'))
 				.setMinValue(0)
 				.setMaxValue(23))
 		.addIntegerOption(option =>
 			option
 				.setName('minutes')
-				.setDescription(getLocale(defaultLocale, 'CMD.SEEK.OPTION.MINUTES'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.SEEK.OPTION.MINUTES'))
 				.setMinValue(0)
 				.setMaxValue(59))
 		.addIntegerOption(option =>
 			option
 				.setName('seconds')
-				.setDescription(getLocale(defaultLocale, 'CMD.SEEK.OPTION.SECONDS'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.SEEK.OPTION.SECONDS'))
 				.setMinValue(0)
 				.setMaxValue(59)),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],

--- a/src/commands/settings.js
+++ b/src/commands/settings.js
@@ -1,13 +1,13 @@
 import { SlashCommandBuilder, PermissionsBitField, ActionRowBuilder, SelectMenuBuilder, EmbedBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks, settingsOptions } from '#lib/util/constants.js';
-import { getLocale, messageDataBuilder, getGuildLocale, settingsPage } from '#lib/util/util.js';
+import { getLocaleString, messageDataBuilder, getGuildLocaleString, settingsPage } from '#lib/util/util.js';
 import { confirmationTimeout, data } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('settings')
-		.setDescription(getLocale(defaultLocale, 'CMD.SETTINGS.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.SETTINGS.DESCRIPTION'))
 		.setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
 	checks: [checks.GUILD_ONLY],
 	permissions: {
@@ -19,7 +19,7 @@ export default {
 		const option = settingsOptions[0];
 		const guildLocale = await data.guild.get(interaction.guild.id, 'settings.locale') ?? defaultLocale;
 		const { current, embeds, actionRow } = await settingsPage(interaction, guildLocale, option);
-		const description = `${getLocale(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocale(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.NAME`)}** ─ ${getLocale(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.DESCRIPTION`)}\n> ${getLocale(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
+		const description = `${getLocaleString(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.NAME`)}** ─ ${getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.DESCRIPTION`)}\n> ${getLocaleString(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
 		const msg = await interaction.replyHandler.reply(
 			[description, ...embeds],
 			{
@@ -29,7 +29,7 @@ export default {
 							new SelectMenuBuilder()
 								.setCustomId('settings')
 								.addOptions(
-									settingsOptions.map(opt => ({ label: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === option })),
+									settingsOptions.map(opt => ({ label: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === option })),
 								),
 						),
 					actionRow,
@@ -41,7 +41,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/commands/shuffle.js
+++ b/src/commands/shuffle.js
@@ -1,12 +1,12 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getLocale } from '#lib/util/util.js';
+import { getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('shuffle')
-		.setDescription(getLocale(defaultLocale, 'CMD.SHUFFLE.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.SHUFFLE.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],

--- a/src/commands/skip.js
+++ b/src/commands/skip.js
@@ -1,12 +1,12 @@
 import { escapeMarkdown, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('skip')
-		.setDescription(getLocale(defaultLocale, 'CMD.SKIP.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.SKIP.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -27,7 +27,7 @@ export default {
 		if (skip.users.length >= skip.required) {
 			const track = await player.queue.skip();
 			await player.queue.start();
-			await interaction.replyHandler.reply(`${await getGuildLocale(interaction.guildId, 'CMD.SKIP.RESPONSE.SUCCESS.VOTED', escapeMarkdown(track.title), track.uri)}\n${await getGuildLocale(interaction.guildId, 'MISC.ADDED_BY', track.requester)}`);
+			await interaction.replyHandler.reply(`${await getGuildLocaleString(interaction.guildId, 'CMD.SKIP.RESPONSE.SUCCESS.VOTED', escapeMarkdown(track.title), track.uri)}\n${await getGuildLocaleString(interaction.guildId, 'MISC.ADDED_BY', track.requester)}`);
 			return player.queue.next();
 		}
 		player.skip = skip;

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -1,13 +1,13 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder } from '#lib/util/util.js';
 import { confirmationTimeout } from '#lib/util/common.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('stop')
-		.setDescription(getLocale(defaultLocale, 'CMD.STOP.DESCRIPTION')),
+		.setDescription(getLocaleString(defaultLocale, 'CMD.STOP.DESCRIPTION')),
 	checks: [checks.GUILD_ONLY, checks.ACTIVE_SESSION, checks.IN_VOICE, checks.IN_SESSION_VOICE],
 	permissions: {
 		user: [],
@@ -19,8 +19,8 @@ export default {
 		if (!player.queue.current || !player.playing && !player.paused) return interaction.replyHandler.locale('MUSIC.PLAYER.PLAYING.NOTHING', { type: 'error' });
 		const msg = await interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.STOP.RESPONSE.CONFIRMATION'))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.STOP.RESPONSE.CONFIRMATION'))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.ACTION_IRREVERSIBLE') }),
 			{
 				type: 'warning',
 				components: [
@@ -29,11 +29,11 @@ export default {
 							new ButtonBuilder()
 								.setCustomId('stop')
 								.setStyle(ButtonStyle.Danger)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CONFIRM')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CONFIRM')),
 							new ButtonBuilder()
 								.setCustomId('cancel')
 								.setStyle(ButtonStyle.Secondary)
-								.setLabel(await getGuildLocale(interaction.guildId, 'MISC.CANCEL')),
+								.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.CANCEL')),
 						),
 				],
 				fetchReply: true,
@@ -43,7 +43,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/commands/volume.js
+++ b/src/commands/volume.js
@@ -1,16 +1,16 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 import { defaultLocale, features, managers } from '#settings';
 import { checks } from '#lib/util/constants.js';
-import { getGuildLocale, getLocale } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString } from '#lib/util/util.js';
 
 export default {
 	data: new SlashCommandBuilder()
 		.setName('volume')
-		.setDescription(getLocale(defaultLocale, 'CMD.VOLUME.DESCRIPTION'))
+		.setDescription(getLocaleString(defaultLocale, 'CMD.VOLUME.DESCRIPTION'))
 		.addIntegerOption(option =>
 			option
 				.setName('new_volume')
-				.setDescription(getLocale(defaultLocale, 'CMD.VOLUME.OPTION.NEW_VOLUME'))
+				.setDescription(getLocaleString(defaultLocale, 'CMD.VOLUME.OPTION.NEW_VOLUME'))
 				.setMinValue(0)
 				.setMaxValue(1000)
 				.setRequired(true)),
@@ -29,8 +29,8 @@ export default {
 		if (features.web.enabled) io.to(`guild:${interaction.guildId}`).emit('volumeUpdate', volume);
 		return interaction.replyHandler.reply(
 			new EmbedBuilder()
-				.setDescription(await getGuildLocale(interaction.guildId, 'CMD.VOLUME.RESPONSE.SUCCESS', volume))
-				.setFooter({ text: await getGuildLocale(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
+				.setDescription(await getGuildLocaleString(interaction.guildId, 'CMD.VOLUME.RESPONSE.SUCCESS', volume))
+				.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MUSIC.PLAYER.FILTER_NOTE') }),
 		);
 	},
 };

--- a/src/components/buttons/format.js
+++ b/src/components/buttons/format.js
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, EmbedBuilder } from 'discord.js';
-import { getGuildLocale, getLocale, messageDataBuilder, settingsPage } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder, settingsPage } from '#lib/util/util.js';
 import { confirmationTimeout, data } from '#lib/util/common.js';
 import { defaultLocale } from '#settings';
 
@@ -13,7 +13,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);
@@ -23,7 +23,7 @@ export default {
 		await data.guild.set(interaction.guildId, 'settings.format', option);
 		const guildLocale = await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale;
 		const { current, embeds, actionRow } = await settingsPage(interaction, guildLocale, 'format');
-		const description = `${getLocale(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.NAME')}** ─ ${getLocale(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.DESCRIPTION')}\n> ${getLocale(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
+		const description = `${getLocaleString(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.NAME')}** ─ ${getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.FORMAT.DESCRIPTION')}\n> ${getLocaleString(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
 		return interaction.replyHandler.reply(
 			[description, ...embeds],
 			{

--- a/src/components/buttons/queue.js
+++ b/src/components/buttons/queue.js
@@ -1,5 +1,5 @@
 import { ButtonBuilder, EmbedBuilder, ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, escapeMarkdown } from 'discord.js';
-import { paginate, msToTime, msToTimeString, getGuildLocale } from '#lib/util/util.js';
+import { paginate, msToTime, msToTimeString, getGuildLocaleString } from '#lib/util/util.js';
 
 export default {
 	name: 'queue',
@@ -10,14 +10,14 @@ export default {
 		if (player && page === 'goto' && pages.length !== 0) {
 			return interaction.showModal(
 				new ModalBuilder()
-					.setTitle(await getGuildLocale(interaction.guildId, 'CMD.QUEUE.MISC.MODAL_TITLE'))
+					.setTitle(await getGuildLocaleString(interaction.guildId, 'CMD.QUEUE.MISC.MODAL_TITLE'))
 					.setCustomId('queue_goto')
 					.addComponents(
 						new ActionRowBuilder()
 							.addComponents(
 								new TextInputBuilder()
 									.setCustomId('queue_goto_input')
-									.setLabel(await getGuildLocale(interaction.guildId, 'CMD.QUEUE.MISC.PAGE'))
+									.setLabel(await getGuildLocaleString(interaction.guildId, 'CMD.QUEUE.MISC.PAGE'))
 									.setStyle(TextInputStyle.Short),
 							),
 					),
@@ -36,7 +36,7 @@ export default {
 				const durationString = track.isStream ? '∞' : msToTimeString(duration, true);
 				return `\`${(firstIndex + index).toString().padStart(largestIndexSize, ' ')}.\` **[${escapeMarkdown(track.title)}](${track.uri})** \`[${durationString}]\` <@${track.requester}>`;
 			}).join('\n'))
-			.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', page, pages.length) });
+			.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.PAGE', page, pages.length) });
 		original.components[0] = ActionRowBuilder.from(original.components[0]);
 		original.components[0].components[0] = ButtonBuilder.from(original.components[0].components[0])
 			.setCustomId(`queue_${page - 1}`)

--- a/src/components/buttons/search.js
+++ b/src/components/buttons/search.js
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, ButtonBuilder, ChannelType, EmbedBuilder, escapeMarkdown, PermissionsBitField, SelectMenuBuilder } from 'discord.js';
-import { getGuildLocale, messageDataBuilder, msToTime, msToTimeString } from '#lib/util/util.js';
+import { getGuildLocaleString, messageDataBuilder, msToTime, msToTimeString } from '#lib/util/util.js';
 import { searchState } from '#lib/util/common.js';
 import { checks } from '#lib/util/constants.js';
 import PlayerHandler from '#lib/PlayerHandler.js';
@@ -39,7 +39,7 @@ export default {
 			}
 			else {
 				msg = 'MUSIC.QUEUE.TRACK_ADDED.MULTIPLE.DEFAULT';
-				extras = [resolvedTracks.length, await getGuildLocale(interaction.guildId, 'MISC.YOUR_SEARCH'), ''] ;
+				extras = [resolvedTracks.length, await getGuildLocaleString(interaction.guildId, 'MISC.YOUR_SEARCH'), ''] ;
 			}
 			if (!player?.connected) {
 				player = interaction.client.music.createPlayer(interaction.guildId);
@@ -63,8 +63,8 @@ export default {
 			const started = player.playing || player.paused;
 			await interaction.replyHandler.reply(
 				new EmbedBuilder()
-					.setDescription(await getGuildLocale(interaction.guildId, msg, ...extras))
-					.setFooter({ text: started ? `${await getGuildLocale(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
+					.setDescription(await getGuildLocaleString(interaction.guildId, msg, ...extras))
+					.setFooter({ text: started ? `${await getGuildLocaleString(interaction.guildId, 'MISC.POSITION')}: ${firstPosition}${endPosition !== firstPosition ? ` - ${endPosition}` : ''}` : null }),
 				{ type: 'success', components: [] },
 			);
 			if (!started) await player.queue.start();
@@ -83,7 +83,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);
@@ -101,7 +101,7 @@ export default {
 				const durationString = track.info.isStream ? '∞' : msToTimeString(duration, true);
 				return `\`${(firstIndex + index).toString().padStart(largestIndexSize, ' ')}.\` **[${escapeMarkdown(track.info.title)}](${track.info.uri})** \`[${durationString}]\``;
 			}).join('\n'))
-			.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', page, pages.length) });
+			.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.PAGE', page, pages.length) });
 		original.components[0] = ActionRowBuilder.from(original.components[0]);
 		original.components[0].components[0] = SelectMenuBuilder.from(original.components[0].components[0])
 			.setOptions(

--- a/src/components/modals/queue.js
+++ b/src/components/modals/queue.js
@@ -1,5 +1,5 @@
 import { ButtonBuilder, ButtonStyle, EmbedBuilder, ActionRowBuilder, escapeMarkdown } from 'discord.js';
-import { paginate, msToTime, msToTimeString, getGuildLocale } from '#lib/util/util.js';
+import { paginate, msToTime, msToTimeString, getGuildLocaleString } from '#lib/util/util.js';
 
 export default {
 	name: 'queue',
@@ -27,7 +27,7 @@ export default {
 				const durationString = track.isStream ? '∞' : msToTimeString(duration, true);
 				return `\`${(firstIndex + index).toString().padStart(largestIndexSize, ' ')}.\` **[${escapeMarkdown(track.title)}](${track.uri})** \`[${durationString}]\` <@${track.requester}>`;
 			}).join('\n'))
-			.setFooter({ text: await getGuildLocale(interaction.guildId, 'MISC.PAGE', page, pages.length) });
+			.setFooter({ text: await getGuildLocaleString(interaction.guildId, 'MISC.PAGE', page, pages.length) });
 		original.components[0] = ActionRowBuilder.from(original.components[0]);
 		original.components[0].components = [];
 		original.components[0].components[0] = new ButtonBuilder()
@@ -38,7 +38,7 @@ export default {
 		original.components[0].components[1] = new ButtonBuilder()
 			.setCustomId('queue_goto')
 			.setStyle(ButtonStyle.Secondary)
-			.setLabel(await getGuildLocale(interaction.guildId, 'MISC.GO_TO')),
+			.setLabel(await getGuildLocaleString(interaction.guildId, 'MISC.GO_TO')),
 		original.components[0].components[2] = new ButtonBuilder()
 			.setCustomId(`queue_${page + 1}`)
 			.setEmoji('➡️')

--- a/src/components/selectmenus/language.js
+++ b/src/components/selectmenus/language.js
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, EmbedBuilder, SelectMenuBuilder } from 'discord.js';
-import { checkLocaleCompletion, getGuildLocale, getLocale, messageDataBuilder, roundTo, settingsPage } from '#lib/util/util.js';
+import { checkLocaleCompletion, getGuildLocaleString, getLocaleString, messageDataBuilder, roundTo, settingsPage } from '#lib/util/util.js';
 import { confirmationTimeout, data } from '#lib/util/common.js';
 import { defaultLocale } from '#settings';
 import { settingsOptions } from '#lib/util/constants.js';
@@ -14,7 +14,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);
@@ -33,7 +33,7 @@ export default {
 		}
 		const guildLocale = await data.guild.get(interaction.guildId, 'settings.locale') ?? defaultLocale;
 		const { current, embeds, actionRow } = await settingsPage(interaction, guildLocale, 'language');
-		const description = `${getLocale(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocale(guildLocale, 'CMD.SETTINGS.MISC.LANGUAGE.NAME')}** ─ ${getLocale(guildLocale, 'CMD.SETTINGS.MISC.LANGUAGE.DESCRIPTION')}\n> ${getLocale(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
+		const description = `${getLocaleString(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.LANGUAGE.NAME')}** ─ ${getLocaleString(guildLocale, 'CMD.SETTINGS.MISC.LANGUAGE.DESCRIPTION')}\n> ${getLocaleString(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
 		const args = [
 			[description, ...embeds],
 			{
@@ -42,7 +42,7 @@ export default {
 						.addComponents(
 							SelectMenuBuilder.from(interaction.message.components[0].components[0])
 								.setOptions(
-									settingsOptions.map(opt => ({ label: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === 'language' })),
+									settingsOptions.map(opt => ({ label: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === 'language' })),
 								),
 						),
 					actionRow,

--- a/src/components/selectmenus/search.js
+++ b/src/components/selectmenus/search.js
@@ -1,5 +1,5 @@
 import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, SelectMenuBuilder } from 'discord.js';
-import { getGuildLocale, messageDataBuilder } from '#lib/util/util.js';
+import { getGuildLocaleString, messageDataBuilder } from '#lib/util/util.js';
 import { searchState } from '#lib/util/common.js';
 
 export default {
@@ -14,7 +14,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);

--- a/src/components/selectmenus/settings.js
+++ b/src/components/selectmenus/settings.js
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, EmbedBuilder, SelectMenuBuilder } from 'discord.js';
-import { getGuildLocale, getLocale, messageDataBuilder, settingsPage } from '#lib/util/util.js';
+import { getGuildLocaleString, getLocaleString, messageDataBuilder, settingsPage } from '#lib/util/util.js';
 import { settingsOptions } from '#lib/util/constants.js';
 import { confirmationTimeout, data } from '#lib/util/common.js';
 import { defaultLocale } from '#settings';
@@ -14,7 +14,7 @@ export default {
 			await message.edit(
 				messageDataBuilder(
 					new EmbedBuilder()
-						.setDescription(await getGuildLocale(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
+						.setDescription(await getGuildLocaleString(message.guildId, 'DISCORD.INTERACTION.EXPIRED')),
 					{ components: [] },
 				),
 			);
@@ -23,7 +23,7 @@ export default {
 		const option = interaction.values[0];
 		const guildLocale = await data.guild.get(interaction.guild.id, 'settings.locale') ?? defaultLocale;
 		const { current, embeds, actionRow } = await settingsPage(interaction, guildLocale, option);
-		const description = `${getLocale(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocale(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.NAME`)}** ─ ${getLocale(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.DESCRIPTION`)}\n> ${getLocale(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
+		const description = `${getLocaleString(guildLocale, 'CMD.SETTINGS.RESPONSE.HEADER', interaction.guild.name)}\n\n**${getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.NAME`)}** ─ ${getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${option.toUpperCase()}.DESCRIPTION`)}\n> ${getLocaleString(guildLocale, 'MISC.CURRENT')}: \`${current}\``;
 		return interaction.replyHandler.reply(
 			[description, ...embeds],
 			{
@@ -33,7 +33,7 @@ export default {
 							new SelectMenuBuilder()
 								.setCustomId('settings')
 								.addOptions(
-									settingsOptions.map(opt => ({ label: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocale(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === option })),
+									settingsOptions.map(opt => ({ label: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.NAME`), description: getLocaleString(guildLocale, `CMD.SETTINGS.MISC.${opt.toUpperCase()}.DESCRIPTION`), value: opt, default: opt === option })),
 								),
 						),
 					actionRow,

--- a/src/events/music/queueFinish.js
+++ b/src/events/music/queueFinish.js
@@ -1,6 +1,6 @@
 import { features } from '#settings';
 import { logger, data } from '#lib/util/common.js';
-import { getGuildLocale } from '#lib/util/util.js';
+import { getGuildLocaleString } from '#lib/util/util.js';
 
 export default {
 	name: 'queueFinish',
@@ -20,6 +20,6 @@ export default {
 		}, 30 * 60 * 1000, queue.player);
 		queue.player.timeoutEnd = Date.now() + (30 * 60 * 1000);
 		if (features.web.enabled) io.to(`guild:${queue.player.guildId}`).emit('timeoutUpdate', queue.player.timeoutEnd);
-		return queue.player.handler.send(`${await getGuildLocale(queue.player.guildId, 'MUSIC.QUEUE.EMPTY')} ${await getGuildLocale(queue.player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (30 * 60))}`, { type: 'warning' });
+		return queue.player.handler.send(`${await getGuildLocaleString(queue.player.guildId, 'MUSIC.QUEUE.EMPTY')} ${await getGuildLocaleString(queue.player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (30 * 60))}`, { type: 'warning' });
 	},
 };

--- a/src/events/music/trackStart.js
+++ b/src/events/music/trackStart.js
@@ -1,6 +1,6 @@
 import { features } from '#settings';
 import { data, logger } from '#lib/util/common.js';
-import { getGuildLocale, msToTime, msToTimeString } from '#lib/util/util.js';
+import { getGuildLocaleString, msToTime, msToTimeString } from '#lib/util/util.js';
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
 
 export default {
@@ -31,15 +31,15 @@ export default {
 		}
 		const format = await data.guild.get(queue.player.guildId, 'settings.format') ?? 'simple';
 		return format === 'simple'
-			? queue.player.handler.send(`${await getGuildLocale(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE', escapeMarkdown(track.title), track.uri, durationString)}\n${await getGuildLocale(queue.player.guildId, 'MISC.ADDED_BY', track.requester)}`)
+			? queue.player.handler.send(`${await getGuildLocaleString(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE', escapeMarkdown(track.title), track.uri, durationString)}\n${await getGuildLocaleString(queue.player.guildId, 'MISC.ADDED_BY', track.requester)}`)
 			: queue.player.handler.send(
 				new EmbedBuilder()
-					.setTitle(await getGuildLocale(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.TITLE'))
+					.setTitle(await getGuildLocaleString(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.TITLE'))
 					.setDescription(`**[${escapeMarkdown(track.title)}](${track.uri})**`)
 					.addFields([
-						{ name: await getGuildLocale(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.DURATION'), value: `\`${durationString}\``, inline: true },
-						{ name: await getGuildLocale(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.UPLOADER'), value: track.author, inline: true },
-						{ name: await getGuildLocale(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.ADDED_BY'), value: `<@${track.requester}>`, inline: true },
+						{ name: await getGuildLocaleString(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.DURATION'), value: `\`${durationString}\``, inline: true },
+						{ name: await getGuildLocaleString(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.UPLOADER'), value: track.author, inline: true },
+						{ name: await getGuildLocaleString(queue.player.guildId, 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.ADDED_BY'), value: `<@${track.requester}>`, inline: true },
 					])
 					.setThumbnail(`https://i.ytimg.com/vi/${track.identifier}/hqdefault.jpg`),
 			);

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -1,6 +1,6 @@
 import { PermissionsBitField, ChannelType, StageInstancePrivacyLevel, EmbedBuilder } from 'discord.js';
 import { logger, data } from '#lib/util/common.js';
-import { getGuildLocale } from '#lib/util/util.js';
+import { getGuildLocaleString } from '#lib/util/util.js';
 import { features } from '#settings';
 
 export default {
@@ -63,7 +63,7 @@ export default {
 				await newState.setSuppressed(false);
 				if (!newState.channel.stageInstance) {
 					try {
-						await newState.channel.createStageInstance({ topic: await getGuildLocale(player.guildId, 'MISC.STAGE_TOPIC'), privacyLevel: StageInstancePrivacyLevel.GuildOnly });
+						await newState.channel.createStageInstance({ topic: await getGuildLocaleString(player.guildId, 'MISC.STAGE_TOPIC'), privacyLevel: StageInstancePrivacyLevel.GuildOnly });
 					}
 					catch (err) {
 						logger.error({ message: `${err.message}\n${err.stack}`, label: 'Quaver' });
@@ -100,8 +100,8 @@ export default {
 				if (features.web.enabled) io.to(`guild:${player.guildId}`).emit('pauseTimeoutUpdate', player.timeoutEnd);
 				return player.handler.send(
 					new EmbedBuilder()
-						.setDescription(`${await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.ALONE.WARNING')} ${await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (5 * 60))}`)
-						.setFooter({ text: await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME') }),
+						.setDescription(`${await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.ALONE.WARNING')} ${await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (5 * 60))}`)
+						.setFooter({ text: await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME') }),
 					{ type: 'warning' },
 				);
 			}
@@ -169,8 +169,8 @@ export default {
 		if (features.web.enabled) io.to(`guild:${player.guildId}`).emit('pauseTimeoutUpdate', player.timeoutEnd);
 		return player.handler.send(
 			new EmbedBuilder()
-				.setDescription(`${await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.ALONE.WARNING')} ${await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (5 * 60))}`)
-				.setFooter({ text: await getGuildLocale(player.guildId, 'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME') }),
+				.setDescription(`${await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.ALONE.WARNING')} ${await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.INACTIVITY.WARNING', Math.floor(Date.now() / 1000) + (5 * 60))}`)
+				.setFooter({ text: await getGuildLocaleString(player.guildId, 'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME') }),
 			{ type: 'warning' },
 		);
 	},

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { readdirSync, readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
 import { createInterface } from 'readline';
 import { features, lavalink, token } from '#settings';
-import { msToTime, msToTimeString, getGuildLocale, getAbsoluteFileURL } from '#lib/util/util.js';
+import { msToTime, msToTimeString, getGuildLocaleString, getAbsoluteFileURL } from '#lib/util/util.js';
 import { logger, data, setLocales } from '#lib/util/common.js';
 import { createServer } from 'https';
 
@@ -152,18 +152,18 @@ export async function shuttingDown(eventType, err) {
 				logger.info({ message: `[G ${player.guildId}] Disconnecting (restarting)`, label: 'Quaver' });
 				const fileBuffer = [];
 				if (player.queue.current && (player.playing || player.paused)) {
-					fileBuffer.push(`${await getGuildLocale(player.guildId, 'MISC.CURRENT')}:`);
+					fileBuffer.push(`${await getGuildLocaleString(player.guildId, 'MISC.CURRENT')}:`);
 					fileBuffer.push(player.queue.current.uri);
 				}
 				if (player.queue.tracks.length > 0) {
-					fileBuffer.push(`${await getGuildLocale(player.guildId, 'MISC.QUEUE')}:`);
+					fileBuffer.push(`${await getGuildLocaleString(player.guildId, 'MISC.QUEUE')}:`);
 					fileBuffer.push(player.queue.tracks.map(track => track.uri).join('\n'));
 				}
 				await player.handler.disconnect();
 				const success = await player.handler.send(
 					new EmbedBuilder()
-						.setDescription(`${await getGuildLocale(player.guildId, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC.PLAYER.RESTARTING.DEFAULT' : 'MUSIC.PLAYER.RESTARTING.CRASHED')}${fileBuffer.length > 0 ? `\n${await getGuildLocale(player.guildId, 'MUSIC.PLAYER.RESTARTING.QUEUE_DATA_ATTACHED')}` : ''}`)
-						.setFooter({ text: await getGuildLocale(player.guildId, 'MUSIC.PLAYER.RESTARTING.APOLOGY') }),
+						.setDescription(`${await getGuildLocaleString(player.guildId, ['exit', 'SIGINT', 'SIGTERM', 'lavalink'].includes(eventType) ? 'MUSIC.PLAYER.RESTARTING.DEFAULT' : 'MUSIC.PLAYER.RESTARTING.CRASHED')}${fileBuffer.length > 0 ? `\n${await getGuildLocaleString(player.guildId, 'MUSIC.PLAYER.RESTARTING.QUEUE_DATA_ATTACHED')}` : ''}`)
+						.setFooter({ text: await getGuildLocaleString(player.guildId, 'MUSIC.PLAYER.RESTARTING.APOLOGY') }),
 					{
 						type: 'warning',
 						files: fileBuffer.length > 0 ? [


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Renames the functions `getLocale()` and `getGuildLocale()`

Makes it more obvious what we're getting a string.
Makes it less difficult to interpret and differentiate that we're getting a string and not a locale code.

e.g.
`defaultLocale` - lang code
`getLocaleString` - string