### PR TITLE
refactor: use a boolean for web.https

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -47,6 +47,7 @@
             ],
             "encryptionKey": "Type an encryption key here",
             "https": {
+                "enabled": false,
                 "key": "key.pem",
                 "cert": "cert.pem"
             }
@@ -109,7 +110,8 @@
 `features.web.encryptionKey` - The encryption key used to secure access tokens.
 
 `features.web.https` - HTTPS configuration.
-> **Note:** If you're not using HTTPS, please remove this property entirely.
+
+`features.web.https.enabled` - Whether or not HTTPS is enabled.
 
 `features.web.https.key` - The path to the HTTPS key file. This is relative to the root folder.
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -44,6 +44,7 @@
             ],
             "encryptionKey": "Type an encryption key here",
             "https": {
+                "enabled": false,
                 "key": "key.pem",
                 "cert": "cert.pem"
             }

--- a/src/lib/util/settings.ts
+++ b/src/lib/util/settings.ts
@@ -49,6 +49,7 @@ export let settings: {
 			allowedOrigins?: string[],
 			encryptionKey?: string,
 			https?: {
+				enabled?: boolean,
 				key?: string,
 				cert?: string,
 			},

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ rl.on('line', async (input): Promise<void> => {
 rl.on('close', async (): Promise<void> => shuttingDown('SIGINT'));
 
 let httpServer;
-if (settings.features.web.https) {
+if (settings.features.web.https.enabled) {
 	httpServer = createServer({
 		key: readFileSync(getAbsoluteFileURL(import.meta.url, ['..', ...settings.features.web.https.key.split('/')])),
 		cert: readFileSync(getAbsoluteFileURL(import.meta.url, ['..', ...settings.features.web.https.cert.split('/')])),


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not appxicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

We have discussed this before that we keep it the way it is, but I still think a boolean would make this better.

Should be toggleable with a boolean instead of removing the properties to toggle it off.