### PR TITLE
refactor(locales): markdown inconsistency

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -84,7 +84,7 @@ export default {
 			NEW_POSITION: 'The new position of the track.'
 		},
 		RESPONSE: {
-			SUCCESS: 'Moved **[%1](%2)** `%3 -> %4`',
+			SUCCESS: 'Moved [**%1**](%2) `%3 -> %4`',
 			QUEUE_INSUFFICIENT_TRACKS: 'There aren\'t enough tracks in the queue to perform a move.',
 			OUT_OF_RANGE: 'Your input was invalid.',
 			MOVING_IN_PLACE: 'You can\'t move a track to the same position it is already in.'
@@ -153,7 +153,7 @@ export default {
 			POSITION: 'The position of the track to remove.'
 		},
 		RESPONSE: {
-			SUCCESS: 'Removed **[%1](%2)**',
+			SUCCESS: 'Removed [**%1**](%2)',
 			QUEUE_EMPTY: 'There are no tracks in the queue to remove.'
 		}
 	},
@@ -225,11 +225,11 @@ export default {
 		DESCRIPTION: 'Skip the current track.',
 		RESPONSE: {
 			SUCCESS: {
-				DEFAULT: 'Skipped **[%1](%2)**',
-				VOTED: 'Skipped **[%1](%2)** by voting'
+				DEFAULT: 'Skipped [**%1**](%2)',
+				VOTED: 'Skipped [**%1**](%2) by voting'
 			},
 			VOTED: {
-				SUCCESS: 'Voted to skip **[%1](%2)** `[%3 / %4]`',
+				SUCCESS: 'Voted to skip [**%1**](%2) `[%3 / %4]`',
 				STATE_UNCHANGED: 'You have already voted to skip this track.'
 			}
 		}

--- a/locales/en/music.js
+++ b/locales/en/music.js
@@ -22,7 +22,7 @@ export default {
 	},
 	PLAYER: {
 		FILTER_NOTE: 'This may take a few seconds to apply',
-		TRACK_SKIPPED_ERROR: 'Skipped **[%1](%2)** as an error occurred: `%3`',
+		TRACK_SKIPPED_ERROR: 'Skipped [**%1**](%2) as an error occurred: `%3`',
 		QUEUE_CLEARED_ERROR: 'Cleared queue as an error occurred multiple times consecutively.',
 		PLAYING: {
 			NOTHING: 'There is nothing playing right now.',


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

`[**x**](y)` makes more sense than `**[x](y)**`.
