### PR TITLE
refactor: use colon for custom IDs

### DIFF
--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -80,12 +80,12 @@ export default {
                 components: [
                     new ActionRowBuilder<ButtonBuilder>().addComponents(
                         new ButtonBuilder()
-                            .setCustomId('queue_0')
+                            .setCustomId('queue:0')
                             .setEmoji('⬅️')
                             .setDisabled(true)
                             .setStyle(ButtonStyle.Primary),
                         new ButtonBuilder()
-                            .setCustomId('queue_goto')
+                            .setCustomId('queue:goto')
                             .setStyle(ButtonStyle.Secondary)
                             .setLabel(
                                 await getGuildLocaleString(
@@ -94,7 +94,7 @@ export default {
                                 ),
                             ),
                         new ButtonBuilder()
-                            .setCustomId('queue_2')
+                            .setCustomId('queue:2')
                             .setEmoji('➡️')
                             .setDisabled(pages.length === 1)
                             .setStyle(ButtonStyle.Primary),

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -156,17 +156,17 @@ export default {
                     ),
                     new ActionRowBuilder<ButtonBuilder>().addComponents(
                         new ButtonBuilder()
-                            .setCustomId('search_0')
+                            .setCustomId('search:0')
                             .setEmoji('⬅️')
                             .setDisabled(true)
                             .setStyle(ButtonStyle.Primary),
                         new ButtonBuilder()
-                            .setCustomId('search_2')
+                            .setCustomId('search:2')
                             .setEmoji('➡️')
                             .setDisabled(pages.length === 1)
                             .setStyle(ButtonStyle.Primary),
                         new ButtonBuilder()
-                            .setCustomId('search_add')
+                            .setCustomId('search:add')
                             .setStyle(ButtonStyle.Success)
                             .setDisabled(true)
                             .setLabel(

--- a/src/components/buttons/format.ts
+++ b/src/components/buttons/format.ts
@@ -61,7 +61,7 @@ export default {
             30 * 1000,
             interaction.message,
         );
-        const option = interaction.customId.split('_')[1];
+        const option = interaction.customId.split(':')[1];
         await data.guild.set(interaction.guildId, 'settings.format', option);
         const guildLocaleCode =
             (await data.guild.get<string>(

--- a/src/components/buttons/queue.ts
+++ b/src/components/buttons/queue.ts
@@ -30,7 +30,7 @@ export default {
                 interaction.guildId,
             ),
             pages = player ? paginate(player.queue.tracks, 5) : [];
-        const target = interaction.customId.split('_')[1];
+        const target = interaction.customId.split(':')[1];
         if (player && target === 'goto' && pages.length !== 0) {
             return interaction.showModal(
                 new ModalBuilder()
@@ -40,11 +40,11 @@ export default {
                             'CMD.QUEUE.MISC.MODAL_TITLE',
                         ),
                     )
-                    .setCustomId('queue_goto')
+                    .setCustomId('queue:goto')
                     .addComponents(
                         new ActionRowBuilder<TextInputBuilder>().addComponents(
                             new TextInputBuilder()
-                                .setCustomId('queue_goto_input')
+                                .setCustomId('queue:goto:input')
                                 .setLabel(
                                     await getGuildLocaleString(
                                         interaction.guildId,
@@ -112,12 +112,12 @@ export default {
         (updated.components[0].components[0] = ButtonBuilder.from(
             original.components[0].components[0] as ButtonComponent,
         )
-            .setCustomId(`queue_${page - 1}`)
+            .setCustomId(`queue:${page - 1}`)
             .setDisabled(page - 1 < 1)),
             (updated.components[0].components[2] = ButtonBuilder.from(
                 original.components[0].components[2] as ButtonComponent,
             )
-                .setCustomId(`queue_${page + 1}`)
+                .setCustomId(`queue:${page + 1}`)
                 .setDisabled(page + 1 > pages.length));
         await interaction.replyHandler.reply(updated.embeds, {
             components: updated.components,

--- a/src/components/buttons/search.ts
+++ b/src/components/buttons/search.ts
@@ -52,7 +52,7 @@ export default {
             );
             return;
         }
-        const target = interaction.customId.split('_')[1];
+        const target = interaction.customId.split(':')[1];
         if (target === 'add') {
             const { bot, io } = await import('#src/main.js');
             const tracks = state.selected;
@@ -386,14 +386,14 @@ export default {
         selectComponent.setMaxValues(selectComponent.options.length);
         updated.components[0].components[0] = selectComponent;
         updated.components[1].components[0] = ButtonBuilder.from(
-            <ButtonComponent>original.components[1].components[0],
+            original.components[1].components[0] as ButtonComponent,
         )
-            .setCustomId(`search_${page - 1}`)
+            .setCustomId(`search:${page - 1}`)
             .setDisabled(page - 1 < 1);
         updated.components[1].components[1] = ButtonBuilder.from(
-            <ButtonComponent>original.components[1].components[1],
+            original.components[1].components[1] as ButtonComponent,
         )
-            .setCustomId(`search_${page + 1}`)
+            .setCustomId(`search:${page + 1}`)
             .setDisabled(page + 1 > pages.length);
         await interaction.replyHandler.reply(updated.embeds, {
             components: updated.components,

--- a/src/components/modals/queue.ts
+++ b/src/components/modals/queue.ts
@@ -27,7 +27,7 @@ export default {
                 interaction.guildId,
             ),
             page = parseInt(
-                interaction.fields.getTextInputValue('queue_goto_input'),
+                interaction.fields.getTextInputValue('queue:goto:input'),
             );
         let pages;
         if (isNaN(page)) {

--- a/src/components/modals/queue.ts
+++ b/src/components/modals/queue.ts
@@ -97,12 +97,12 @@ export default {
         updated.components[0] =
             new ActionRowBuilder<ButtonBuilder>().addComponents(
                 new ButtonBuilder()
-                    .setCustomId(`queue_${page - 1}`)
+                    .setCustomId(`queue:${page - 1}`)
                     .setEmoji('⬅️')
                     .setDisabled(page - 1 < 1)
                     .setStyle(ButtonStyle.Primary),
                 new ButtonBuilder()
-                    .setCustomId('queue_goto')
+                    .setCustomId('queue:goto')
                     .setStyle(ButtonStyle.Secondary)
                     .setLabel(
                         await getGuildLocaleString(
@@ -111,7 +111,7 @@ export default {
                         ),
                     ),
                 new ButtonBuilder()
-                    .setCustomId(`queue_${page + 1}`)
+                    .setCustomId(`queue:${page + 1}`)
                     .setEmoji('➡️')
                     .setDisabled(page + 1 > pages.length)
                     .setStyle(ButtonStyle.Primary),

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -225,7 +225,7 @@ export default {
         }
         if (interaction.isButton()) {
             const button = interaction.client.buttons.get(
-                interaction.customId.split('_')[0],
+                interaction.customId.split(':')[0],
             ) as Button;
             if (!button) return;
             logger.info({
@@ -274,7 +274,7 @@ export default {
         }
         if (interaction.isSelectMenu()) {
             const selectmenu = interaction.client.selectmenus.get(
-                interaction.customId.split('_')[0],
+                interaction.customId.split(':')[0],
             ) as SelectMenu;
             if (!selectmenu) return;
             logger.info({
@@ -323,7 +323,7 @@ export default {
         }
         if (interaction.isModalSubmit()) {
             const modal = interaction.client.modals.get(
-                interaction.customId.split('_')[0],
+                interaction.customId.split(':')[0],
             ) as ModalSubmit;
             if (!modal) return;
             logger.info({

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -376,7 +376,7 @@ export async function buildSettingsPage(
                 )) ?? 'simple';
             actionRow.addComponents(
                 new ButtonBuilder()
-                    .setCustomId('format_simple')
+                    .setCustomId('format:simple')
                     .setLabel(
                         getLocaleString(
                             guildLocaleCode,
@@ -390,7 +390,7 @@ export async function buildSettingsPage(
                     )
                     .setDisabled(current === 'simple'),
                 new ButtonBuilder()
-                    .setCustomId('format_detailed')
+                    .setCustomId('format:detailed')
                     .setLabel(
                         getLocaleString(
                             guildLocaleCode,


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
uses colons as the delimiter for custom IDs instead of the common underscore to prevent conflicts (this is a parity PR with Warden)