### PR TITLE
feat: configurable default source

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -254,6 +254,19 @@ export default {
                 NAME: 'DJ Role',
                 DESCRIPTION: 'A role allowing requester check bypass.',
             },
+            SOURCE: {
+                NAME: 'Source',
+                DESCRIPTION: 'The default source to use. Affects the /play command.',
+                OPTIONS: {
+                    YOUTUBE: 'YouTube',
+                    YOUTUBEMUSIC: 'YouTube Music',
+                    DEEZER: 'Deezer',
+                    SOUNDCLOUD: 'SoundCloud',
+                    YANDEXMUSIC: 'Yandex Music',
+                    VKMUSIC: 'VK Music',
+                    TIDAL: 'Tidal',
+                },
+            },
             AUTOLYRICS: {
                 NAME: 'Auto Lyrics',
                 DESCRIPTION: 'Automatically send lyrics for every track.',

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -6,7 +6,11 @@ import type {
     QuaverSong,
 } from '#src/lib/util/common.d.js';
 import { data, MessageOptionsBuilderType } from '#src/lib/util/common.js';
-import { Check, queryOverrides } from '#src/lib/util/constants.js';
+import {
+    acceptableSources,
+    Check,
+    queryOverrides,
+} from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
 import type {
@@ -120,10 +124,16 @@ export default {
         let tracks: QuaverSong[] = [],
             msg = '',
             extras = [];
+        const source =
+            (await data.guild.get<string>(
+                interaction.guildId,
+                'settings.source',
+            )) ?? Object.keys(acceptableSources)[0];
+        const preQuery = acceptableSources[source];
         const result = await interaction.client.music.api.loadTracks(
             queryOverrides.some((q): boolean => query.startsWith(q))
                 ? query
-                : `ytmsearch:${query}`,
+                : `${preQuery}${query}`,
         );
         switch (result.loadType) {
             case 'playlist':

--- a/src/events/web/update.ts
+++ b/src/events/web/update.ts
@@ -5,7 +5,11 @@ import type {
     QuaverSong,
 } from '#src/lib/util/common.d.js';
 import { data } from '#src/lib/util/common.js';
-import { Check, queryOverrides } from '#src/lib/util/constants.js';
+import {
+    acceptableSources,
+    Check,
+    queryOverrides,
+} from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
     getFailedChecks,
@@ -89,10 +93,16 @@ export default {
                 }
                 const query = item.value;
                 let tracks = [];
+                const source =
+                    (await data.guild.get<string>(
+                        guildId,
+                        'settings.source',
+                    )) ?? Object.keys(acceptableSources)[0];
+                const preQuery = acceptableSources[source];
                 const result = await bot.music.api.loadTracks(
                     queryOverrides.some((q): boolean => query.startsWith(q))
                         ? query
-                        : `ytmsearch:${query}`,
+                        : `${preQuery}${query}`,
                 );
                 switch (result.loadType) {
                     case 'playlist':

--- a/src/lib/util/common.d.ts
+++ b/src/lib/util/common.d.ts
@@ -36,6 +36,7 @@ export type SettingsPageOptions =
     | 'language'
     | 'format'
     | 'dj'
+    | 'source'
     | 'autolyrics'
     | 'smartqueue';
 

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -41,7 +41,11 @@ export const settingsOptions = [
     'language',
     'format',
     'dj',
+    'source',
     ...(settings.features.autolyrics.enabled ? ['autolyrics'] : []),
     ...(settings.features.smartqueue.enabled ? ['smartqueue'] : []),
 ];
+
 export const queryOverrides: string[] = [];
+export const sourceManagers: string[] = [];
+export const acceptableSources: Record<string, string> = {};

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -10,7 +10,13 @@ import type {
     WhitelistedFeatures,
 } from '#src/lib/util/common.d.js';
 import { data, locales, MessageOptionsBuilderType } from '#src/lib/util/common.js';
-import { Check, Language, queryOverrides } from '#src/lib/util/constants.js';
+import {
+    acceptableSources,
+    Check,
+    Language,
+    queryOverrides,
+    sourceManagers as extSourceManagers,
+} from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import { getAbsoluteFileURL } from '@zptxdev/zptx-lib';
 import type {
@@ -771,6 +777,32 @@ export async function buildSettingsPage(
             );
             break;
         }
+        case 'source': {
+            current =
+                (await data.guild.get<string>(
+                    interaction.guildId,
+                    'settings.source',
+                )) ?? Object.keys(acceptableSources)[0];
+            actionRow.addComponents(
+                new StringSelectMenuBuilder().setCustomId('source').addOptions(
+                    Object.keys(acceptableSources).map(
+                        (source: string): APISelectMenuOption => ({
+                            label: getLocaleString(
+                                guildLocaleCode,
+                                `CMD.SETTINGS.MISC.SOURCE.OPTIONS.${source.toUpperCase()}`,
+                            ),
+                            value: source,
+                            default: current === source,
+                        }),
+                    ),
+                ),
+            );
+            current = `\`${getLocaleString(
+                guildLocaleCode,
+                `CMD.SETTINGS.MISC.SOURCE.OPTIONS.${current.toUpperCase()}`,
+            )}\``;
+            break;
+        }
         case 'autolyrics': {
             const enabled = await data.guild.get<boolean>(
                 interaction.guildId,
@@ -835,4 +867,24 @@ export function updateQueryOverrides(sourceManagers: readonly string[]): void {
             : []),
         ...(sourceManagers.includes('soundcloud') ? ['scsearch:'] : []),
     );
+}
+
+/**
+ * Updates the source managers.
+ * @param sourceManagers - The source managers to use.
+ */
+export function updateSourceManagers(sourceManagers: readonly string[]): void {
+    extSourceManagers.push(...sourceManagers);
+}
+
+/**
+ * Updates the acceptable sources.
+ * @param sourceManagers - The source managers to use.
+ */
+export function updateAcceptableSources(
+    sourceManagers: Record<string, string>,
+): void {
+    for (const [key, value] of Object.entries(sourceManagers)) {
+        acceptableSources[key] = value;
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,9 @@ import {
 import { settings } from '#src/lib/util/settings.js';
 import {
     getGuildLocaleString,
+    updateAcceptableSources,
     updateQueryOverrides,
+    updateSourceManagers,
 } from '#src/lib/util/util.js';
 import { load as effectsLoad } from '@lavaclient/plugin-effects';
 import { load as queueLoad } from '@lavaclient/plugin-queue';
@@ -260,7 +262,6 @@ if (io) {
                     name: string;
                     once: boolean;
                     execute(
-                        // eslint-disable-next-line @typescript-eslint/no-shadow
                         socket: Socket,
                         callback: () => void,
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,6 +354,37 @@ if (
     });
 }
 updateQueryOverrides(info.sourceManagers);
+
+const acceptableSources = {
+    youtubemusic: 'ytmsearch:',
+    youtube: 'ytsearch:',
+    deezer: 'dzsearch:',
+    soundcloud: 'scsearch:',
+    yandexmusic: 'ymsearch:',
+    vkmusic: 'vksearch:',
+    tidal: 'tdsearch:',
+};
+if (
+    info.sourceManagers.length === 0 ||
+    !info.sourceManagers.some((source): boolean =>
+        Object.keys(acceptableSources).includes(source),
+    )
+) {
+    logger.warn({
+        message:
+            'No acceptable sources were found. It is HIGHLY unlikely that this instance will work as intended.',
+        label: 'Lavalink',
+    });
+}
+const sm = [...info.sourceManagers];
+if (info.sourceManagers.includes('youtube')) sm.push('youtubemusic');
+for (const source of Object.keys(acceptableSources)) {
+    if (sm.includes(source)) continue;
+    // @ts-expect-error - expected behaviour with check above
+    delete acceptableSources[source];
+}
+updateSourceManagers(info.sourceManagers);
+updateAcceptableSources(acceptableSources);
 
 let inProgress = false;
 


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Adds configurable default source to allow for changing from ytmsearch to something else. (useful for recent ratelimit issues)