### PR TITLE
refactor(voiceStateUpdate): reduce nesting and flatten for clarity

### DIFF
--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -179,7 +179,7 @@ async function onChannelJoinOrMove(
             newState.channelId,
         );
     }
-    // newState#channel is always defined for join/move states, so optional chaining is unnecessary
+    // In this context newState#channel is always defined for join/move states, so optional chaining is unnecessary
     const hasNewChannelUsers = newState.channel.members.filter(isUser).size > 0;
     if (hasNewChannelUsers && player.pauseTimeout) {
         await resumeChannelSession(io, player);
@@ -242,7 +242,7 @@ export default {
         );
         const playerVoice = player.voice;
         const hasQuaverDisconnected = isOldQuaverStateUpdate && !newChannelId;
-        // To ensure it does not persist in an inactive session, disable stay for this guild
+        // To ensure Quaver does not persist in an inactive session, disable stay feature for this guild
         if (hasQuaverDisconnected && isGuildStayEnabled) {
             await guildDatabase.set(playerId, 'settings.stay.enabled', false);
         }
@@ -265,7 +265,7 @@ export default {
         // explicitly use booleans for Quaver's state update and newState#channelId
         const isQuaverJoinOrMoveState = isOldQuaverStateUpdate && newChannelId;
         const newChannel = newState.channel;
-        // In this context, newState#channel can be null because of leave states, so optional chaining is necessary
+        // In this context newState#channel can be null because of leave states, so optional chaining is necessary
         const newChannelType = newChannel?.type;
         // To keep the dashboard updated with the latest session details, emit channel events for this guild
         if (isQuaverJoinOrMoveState && settings.features.web.enabled) {
@@ -387,10 +387,9 @@ export default {
         const isUserLeaveOrMoveState =
             !isOldQuaverStateUpdate && oldChannelId === playerVoice.channelId;
         // Since the last user left or moved out from Quaver's channel and the guild's stay feature is disabled, handle the empty channel
-        // In this context, oldState#channel is always defined for leave/move states, so optional chaining is unnecessary
         if (
             isUserLeaveOrMoveState &&
-            oldState.channel.members.filter(isUser).size < 1 &&
+            oldState.channel?.members.filter(isUser).size < 1 &&
             !isGuildStayEnabled
         ) {
             await onChannelEmpty(

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -384,14 +384,12 @@ export default {
             await resumeChannelSession(io, player);
             return;
         }
-        const hasUserLeftQuaverChannel =
-            !isOldQuaverStateUpdate &&
-            !newChannelId &&
-            oldChannelId === playerVoice.channelId;
-        // Since the last user left Quaver's channel and the guild's stay feature is disabled, handle the empty channel
-        // In this context, oldState#channel is always defined for leave states, so optional chaining is unnecessary
+        const isUserLeaveOrMoveState =
+            !isOldQuaverStateUpdate && oldChannelId === playerVoice.channelId;
+        // Since the last user left or moved out from Quaver's channel and the guild's stay feature is disabled, handle the empty channel
+        // In this context, oldState#channel is always defined for leave/move states, so optional chaining is unnecessary
         if (
-            hasUserLeftQuaverChannel &&
+            isUserLeaveOrMoveState &&
             oldState.channel.members.filter(isUser).size < 1 &&
             !isGuildStayEnabled
         ) {

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -363,7 +363,7 @@ export default {
                     }
                 }
             }
-            // To prevent a regression bug where in Quaver remains silent in Stage channels, unsuppress Quaver after stage instance creation
+            // To prevent a regression bug in which Quaver remains silent in stage channels, unsuppress Quaver after stage instance creation
             await newState.setSuppressed(false);
             await onChannelJoinOrMove(
                 io,

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -142,7 +142,7 @@ async function onChannelEmpty(
     const playerVoice = player.voice;
     const playerVoiceChannelId = playerVoice.channelId;
     // To ensure that Quaver does not set pauseTimeout if timeout or pauseTimeout already exists, do not pause the session
-    // To ensure that Quaver does not set a pauseTimeout after a stage ends, do not pause the session
+    // To ensure that Quaver does not set pauseTimeout after a stage ends, do not pause the session
     if (player.timeout || player.pauseTimeout || !playerVoiceChannelId) {
         return;
     }

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -6,7 +6,7 @@ import {
 } from '#src/lib/util/common.js';
 import { settings } from '#src/lib/util/settings.js';
 import { getGuildLocaleString } from '#src/lib/util/util.js';
-import type { VoiceState } from 'discord.js';
+import type { GuildMember, VoiceState } from 'discord.js';
 import {
     ChannelType,
     EmbedBuilder,
@@ -18,6 +18,10 @@ import type { DefaultEventsMap, Server } from 'socket.io';
 const PAUSE_TIMEOUT_SECONDS = 5 * 60;
 
 const guildDatabase = data.guild;
+
+function isUser(member: GuildMember): boolean {
+    return !member.user.bot;
+}
 
 async function pauseChannelSession(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
@@ -173,7 +177,7 @@ async function onChannelJoinOrMove(
     }
     // newState#channel is always defined for join/move states, so optional chaining is unnecessary
     if (
-        newState.channel.members.filter((m): boolean => !m.user.bot).size > 0 &&
+        newState.channel.members.filter(isUser).size > 0 &&
         player.pauseTimeout
     ) {
         await resumeChannelSession(io, player);
@@ -181,8 +185,7 @@ async function onChannelJoinOrMove(
     }
     // oldState#channel can be null for join/move states, so optional chaining is necessary
     if (
-        oldState.channel?.members.filter((m): boolean => !m.user.bot).size <
-            1 &&
+        oldState.channel?.members.filter(isUser).size < 1 &&
         !isGuildStayEnabled
     ) {
         await onChannelEmpty(
@@ -398,8 +401,7 @@ export default {
         // In this context, oldState#channel is always defined for leave states, so optional chaining is unnecessary
         if (
             hasUserLeftQuaverChannel &&
-            oldState.channel.members.filter((m): boolean => !m.user.bot).size <
-                1 &&
+            oldState.channel.members.filter(isUser).size < 1 &&
             !isGuildStayEnabled
         ) {
             await onChannelEmpty(

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -240,7 +240,6 @@ export default {
                 message: `[G ${playerId}] Cleaning up (disconnected)`,
                 label: 'Quaver',
             });
-            playerVoice.channelId = null;
             await playerHandler.locale(
                 'MUSIC.SESSION_ENDED.FORCED.DISCONNECTED',
                 { type: MessageOptionsBuilderType.Warning },

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -331,14 +331,17 @@ export default {
                 await playerHandler.disconnect();
                 return;
             }
-            if (!channelPermissions.has(PermissionsBitField.StageModerator)) {
-                if (isGuildStayEnabled) {
-                    await guildDatabase.set(
-                        playerId,
-                        'settings.stay.enabled',
-                        false,
-                    );
-                }
+            const hasStageModerator = channelPermissions.has(
+                PermissionsBitField.StageModerator,
+            );
+            if (!hasStageModerator && isGuildStayEnabled) {
+                await guildDatabase.set(
+                    playerId,
+                    'settings.stay.enabled',
+                    false,
+                );
+            }
+            if (!hasStageModerator) {
                 await playerHandler.locale(
                     'MUSIC.SESSION_ENDED.FORCED.STAGE_NOT_MODERATOR',
                     { type: MessageOptionsBuilderType.Warning },

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -166,9 +166,12 @@ async function onChannelJoinOrMove(
     newState: VoiceState,
     isGuildStayEnabled: boolean | unknown,
     isOldQuaverStateUpdate: boolean,
-    isInGuildStayChannel: boolean,
 ): Promise<void> {
-    if (!isInGuildStayChannel) {
+    const guildStayChannelId = await guildDatabase.get(
+        player.id,
+        'settings.stay.channel',
+    );
+    if (isGuildStayEnabled && guildStayChannelId !== newState.channelId) {
         await guildDatabase.set(
             player.id,
             'settings.stay.channel',
@@ -290,12 +293,6 @@ export default {
                 PermissionsBitField.Flags.Speak,
             ]),
         );
-        const guildStayChannelId = await guildDatabase.get(
-            playerId,
-            'settings.stay.channel',
-        );
-        const isInGuildStayChannel =
-            isGuildStayEnabled && guildStayChannelId === newChannelId;
         if (
             isQuaverJoinOrMoveState &&
             newChannelType === ChannelType.GuildVoice
@@ -316,7 +313,6 @@ export default {
                 newState,
                 isGuildStayEnabled,
                 isOldQuaverStateUpdate,
-                isInGuildStayChannel,
             );
             return;
         }
@@ -380,7 +376,6 @@ export default {
                 newState,
                 isGuildStayEnabled,
                 isOldQuaverStateUpdate,
-                isInGuildStayChannel,
             );
             return;
         }

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -108,9 +108,9 @@ async function resumeChannelSession(
 async function onChannelEmpty(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
+    oldState: VoiceState,
     isOldQuaverStateUpdate: boolean,
     isGuildStayEnabled: boolean | unknown,
-    oldState: VoiceState,
 ): Promise<void> {
     const playerId = player.id;
     const isPlayerIdle =
@@ -188,9 +188,9 @@ async function onChannelJoinOrMove(
         await onChannelEmpty(
             io,
             player,
+            oldState,
             isOldQuaverStateUpdate,
             isGuildStayEnabled,
-            oldState,
         );
     }
 }
@@ -405,9 +405,9 @@ export default {
             await onChannelEmpty(
                 io,
                 player,
+                oldState,
                 isOldQuaverStateUpdate,
                 isGuildStayEnabled,
-                oldState,
             );
         }
     },

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -381,7 +381,7 @@ export default {
             );
             return;
         }
-        // Since a user joined the channel while the session was paused, resume the session
+        // Since a user joined Quaver's channel while the session was paused, resume the session
         if (
             !isOldQuaverStateUpdate &&
             newChannelId === playerVoice.channelId &&

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -179,26 +179,21 @@ async function onChannelJoinOrMove(
         );
     }
     // newState#channel is always defined for join/move states, so optional chaining is unnecessary
-    if (
-        newState.channel.members.filter(isUser).size > 0 &&
-        player.pauseTimeout
-    ) {
+    const hasNewChannelUsers = newState.channel.members.filter(isUser).size > 0;
+    if (hasNewChannelUsers && player.pauseTimeout) {
         await resumeChannelSession(io, player);
+    }
+    // To prevent Quaver from handling a channel that still has users or the guild's stay feature is enabled, do not handle the non-empty channel
+    if (hasNewChannelUsers || isGuildStayEnabled) {
         return;
     }
-    // oldState#channel can be null for join/move states, so optional chaining is necessary
-    if (
-        oldState.channel?.members.filter(isUser).size < 1 &&
-        !isGuildStayEnabled
-    ) {
-        await onChannelEmpty(
-            io,
-            player,
-            oldState,
-            isOldQuaverStateUpdate,
-            isGuildStayEnabled,
-        );
-    }
+    await onChannelEmpty(
+        io,
+        player,
+        oldState,
+        isOldQuaverStateUpdate,
+        isGuildStayEnabled,
+    );
 }
 
 export default {

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -234,16 +234,10 @@ export default {
             return;
         }
         const playerId = player.id;
-        const guildStayChannelId = await guildDatabase.get(
-            playerId,
-            'settings.stay.channel',
-        );
         const isGuildStayEnabled = await guildDatabase.get(
             playerId,
             'settings.stay.enabled',
         );
-        const isInGuildStayChannel =
-            isGuildStayEnabled && guildStayChannelId === newChannelId;
         const playerVoice = player.voice;
         const hasQuaverDisconnected = isOldQuaverStateUpdate && !newChannelId;
         // To ensure it does not persist in an inactive session, disable stay for this guild
@@ -293,6 +287,12 @@ export default {
                 PermissionsBitField.Flags.Speak,
             ]),
         );
+        const guildStayChannelId = await guildDatabase.get(
+            playerId,
+            'settings.stay.channel',
+        );
+        const isInGuildStayChannel =
+            isGuildStayEnabled && guildStayChannelId === newChannelId;
         if (
             isQuaverJoinOrMoveState &&
             newChannelType === ChannelType.GuildVoice

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -27,8 +27,8 @@ async function pauseChannelSession(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
 ): Promise<void> {
-    const playerId = player.id;
     await player.pause();
+    const playerId = player.id;
     if (settings.features.web.enabled) {
         io.to(`guild:${playerId}`).emit('pauseUpdate', player.paused);
     }

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -125,7 +125,9 @@ async function onChannelEmpty(
         await guildDatabase.set(playerId, 'settings.stay.enabled', false);
     }
     const playerHandler = player.handler;
-    if (isPlayerIdle) {
+    const playerVoice = player.voice;
+    const playerVoiceChannelId = playerVoice.channelId;
+    if (isPlayerIdle && playerVoiceChannelId) {
         logger.info({
             message: `[G ${playerId}] Disconnecting (alone)`,
             label: 'Quaver',
@@ -139,8 +141,6 @@ async function onChannelEmpty(
         await playerHandler.disconnect();
         return;
     }
-    const playerVoice = player.voice;
-    const playerVoiceChannelId = playerVoice.channelId;
     // To ensure that Quaver does not set pauseTimeout if timeout or pauseTimeout already exists, do not pause the session
     if (player.timeout || player.pauseTimeout || !playerVoiceChannelId) {
         return;
@@ -235,7 +235,7 @@ export default {
             await guildDatabase.set(playerId, 'settings.stay.enabled', false);
         }
         // To reset states, properly handle disconnection
-        if (hasQuaverDisconnected) {
+        if (hasQuaverDisconnected && !playerVoice.channelId) {
             logger.info({
                 message: `[G ${playerId}] Cleaning up (disconnected)`,
                 label: 'Quaver',

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -142,19 +142,7 @@ async function onChannelEmpty(
     const playerVoice = player.voice;
     const playerVoiceChannelId = playerVoice.channelId;
     // To ensure that Quaver does not set pauseTimeout if timeout or pauseTimeout already exists, do not pause the session
-    // To ensure that Quaver does not set pauseTimeout after a stage ends, do not pause the session
     if (player.timeout || player.pauseTimeout || !playerVoiceChannelId) {
-        return;
-    }
-    const voiceChannel = oldState.client.guilds.cache
-        .get(playerId)
-        .channels.cache.get(playerVoiceChannelId);
-    // From commit https://github.com/ZPTXDev/Quaver/commit/6f405c5dce1a94cf788000229070ae8a8eeef7cb
-    // This check will be removed once confirmed to be redundant
-    if (
-        voiceChannel.type === ChannelType.GuildStageVoice &&
-        !voiceChannel.stageInstance
-    ) {
         return;
     }
     await pauseChannelSession(io, player);

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -381,7 +381,7 @@ export default {
             );
             return;
         }
-        // Since a user joined the channel while Quaver was paused for inactivity, resume the session
+        // Since a user joined the channel while the session was paused, resume the session
         if (
             !isOldQuaverStateUpdate &&
             newChannelId === playerVoice.channelId &&

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -216,6 +216,7 @@ export default {
                 hasEnforcedStateUpdates ||
                 hasVoluntaryStateUpdates);
         // Since Quaver is expected to continue playback despite its own state updates, do not operate
+        // Handles ignoring state updates from self-deafening or unsuppressing itself from starting tracks
         if (isOldQuaverStateUpdate && hasSameChannelStateUpdates) {
             return;
         }


### PR DESCRIPTION
Context: https://discord.com/channels/906471497231630336/920107978760261663/1355600350249488566
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [x] Major change
- [ ] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.

I'm looking for feedback on this refactor and any suggestions for improvement. Let me know if any changes are needed to better align with the codebase.

Some verbose comments were removed and comments were rewritten like this: `<reasoning statement>, <action statement>`

This pull request carefully refactors the listener for `Client#voiceStateUpdate` and aims to reduce code complexity, flattens out the flow of statements so they're less hard to traverse and read. Applies minor optimizations and simplifies some checks. So uh, basically reduces code duplication and nesting. Adds helper functions with their clear responsibilities. It should and will not change any of existing intended functionality.

Refines conditions and statements to handle and focus only within intended functionality.

Detached commit log:
- refactor(voiceStateUpdate): clearly define magic numbers as a constant
- docs(voiceStateUpdate): update comments
- refactor(voiceStateUpdate): 24/7 was checked twice
- refactor(voiceStateUpdate): store result of channel permissions
- refactor(voiceStateUpdate): do nothing when Player or Player#Handler is unavailable
- refactor(voiceStateUpdate): store result of checks where needed
- refactor(voiceStateUpdate): also nullify Player#pauseTimeout when Quaver disconnects from being moved
- refactor(voiceStateUpdate): optimize property access and prevent desynchronization
    - Store property values where necessary to reduce redundant lookups
    - This avoids making constants for properties that may change to prevent desynchronization
- refactor(voiceStateUpdate): pauseTimeout was checked twice when a user joins in or moves to Quaver's channel and pauseTimeout is set
- refactor(voiceStateUpdate): nullify Player#pauseTimeout as a form of deletion when resuming sessions when moved
- refactor(voiceStateUpdate): distinguish between the cause whether it was from the user leaving or from quaver joining/moving to a channel when setting a pause timeout
- refactor(voiceStateUpdate): remove now redundant pauseTimeout fallthrough check for when a user's state updated in the same channel
- refactor(voiceStateUpdate): redundant player retrieval, sink player instead and hoist "another bot state update" check and "quaver same channel" check


