### PR TITLE
refactor(voiceStateUpdate): remove unused parameter

### DIFF
--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -113,7 +113,6 @@ async function resumeChannelSession(
 async function onChannelEmpty(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
-    oldState: VoiceState,
     isOldQuaverStateUpdate: boolean,
     isGuildStayEnabled: boolean | unknown,
 ): Promise<void> {
@@ -151,7 +150,6 @@ async function onChannelEmpty(
 async function onChannelJoinOrMove(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
-    oldState: VoiceState,
     newState: VoiceState,
     isGuildStayEnabled: boolean | unknown,
     isOldQuaverStateUpdate: boolean,
@@ -179,7 +177,6 @@ async function onChannelJoinOrMove(
     await onChannelEmpty(
         io,
         player,
-        oldState,
         isOldQuaverStateUpdate,
         isGuildStayEnabled,
     );
@@ -304,7 +301,6 @@ export default {
             await onChannelJoinOrMove(
                 io,
                 player,
-                oldState,
                 newState,
                 isGuildStayEnabled,
                 isOldQuaverStateUpdate,
@@ -368,7 +364,6 @@ export default {
             await onChannelJoinOrMove(
                 io,
                 player,
-                oldState,
                 newState,
                 isGuildStayEnabled,
                 isOldQuaverStateUpdate,
@@ -395,7 +390,6 @@ export default {
             await onChannelEmpty(
                 io,
                 player,
-                oldState,
                 isOldQuaverStateUpdate,
                 isGuildStayEnabled,
             );


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Because neither TypeScript nor ESLint warned about this.
Also adjusts the callers' arguments since the parameter wasn't used anymore (from a prior pr)
