### PR TITLE
fix: sanitise placeholder inputs

### DIFF
--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -67,8 +67,16 @@ export function getLocaleString(
     }
     if (!localeString) return stringPath;
     const safeVars = vars.map((v): string => encodeURI(escapeMarkdown(v)));
+    const varMap: Record<string, string> = {};
     safeVars.forEach((v, i): void => {
-        localeString = localeString.replace(`%${i + 1}`, v);
+        varMap[`%${i + 1}`] = v;
+    });
+    localeString = localeString.replace(/%\d+/g, (match): string => {
+        const index = parseInt(match.slice(1), 10);
+        if (isNaN(index) || index < 1 || index > safeVars.length) {
+            return match;
+        }
+        return varMap[match];
     });
     return decodeURI(localeString);
 }

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -9,11 +9,7 @@ import type {
     SettingsPageOptions,
     WhitelistedFeatures,
 } from '#src/lib/util/common.d.js';
-import {
-    data,
-    locales,
-    MessageOptionsBuilderType,
-} from '#src/lib/util/common.js';
+import { data, locales, MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import {
     acceptableSources,
     Check,
@@ -55,7 +51,7 @@ import type { ComponentInteractions } from '#src/events/interactionCreate.d.js';
  * @param vars - The extra variables required in some localized strings.
  * @returns The localized string, or LOCALE_MISSING if the locale is missing, or stringPath if the string is missing.
  */
-export function getLocaleString(
+function getLocaleString(
     localeCode: string,
     stringPath: string,
     ...vars: string[]
@@ -70,10 +66,11 @@ export function getLocaleString(
         localeString = get(strings, stringPath);
     }
     if (!localeString) return stringPath;
-    vars.forEach(
-        (v, i): string => (localeString = localeString.replace(`%${i + 1}`, v)),
-    );
-    return localeString;
+    const safeVars = vars.map((v): string => encodeURI(escapeMarkdown(v)));
+    safeVars.forEach((v, i): void => {
+        localeString = localeString.replace(`%${i + 1}`, v);
+    });
+    return decodeURI(localeString);
 }
 
 /**

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -51,7 +51,7 @@ import type { ComponentInteractions } from '#src/events/interactionCreate.d.js';
  * @param vars - The extra variables required in some localized strings.
  * @returns The localized string, or LOCALE_MISSING if the locale is missing, or stringPath if the string is missing.
  */
-export function getLocaleString(
+function getLocaleString(
     localeCode: string,
     stringPath: string,
     ...vars: string[]
@@ -66,10 +66,11 @@ export function getLocaleString(
         localeString = get(strings, stringPath);
     }
     if (!localeString) return stringPath;
-    vars.forEach(
-        (v, i): string => (localeString = localeString.replace(`%${i + 1}`, v)),
-    );
-    return localeString;
+    const safeVars = vars.map((v): string => encodeURI(escapeMarkdown(v)));
+    safeVars.forEach((v, i): void => {
+        localeString = localeString.replace(`%${i + 1}`, v);
+    });
+    return decodeURI(localeString);
 }
 
 /**

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -51,7 +51,7 @@ import type { ComponentInteractions } from '#src/events/interactionCreate.d.js';
  * @param vars - The extra variables required in some localized strings.
  * @returns The localized string, or LOCALE_MISSING if the locale is missing, or stringPath if the string is missing.
  */
-function getLocaleString(
+export function getLocaleString(
     localeCode: string,
     stringPath: string,
     ...vars: string[]


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [ ] Critical
- [x] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Fixes lack of placeholder input sanitisation, using encodeURI and escapeMarkdown (from d.js) to sanitise strings
Fixes #1354 as a result