### PR TITLE
fix: update track end reason

### DIFF
--- a/locales/en/music.js
+++ b/locales/en/music.js
@@ -22,7 +22,7 @@ export default {
     },
     PLAYER: {
         FILTER_NOTE: 'This may take a few seconds to apply',
-        TRACK_SKIPPED_ERROR: 'Skipped [**%1**](%2) as an error occurred: `%3`',
+        TRACK_SKIPPED_ERROR: 'Skipped [**%1**](%2) as an error occurred while loading the track.',
         QUEUE_CLEARED_ERROR: 'Cleared queue as an error occurred multiple times consecutively.',
         LOOP_TRACK_DISABLED: 'Disabled looping as the track is less than 15 seconds long.',
         LOOP_QUEUE_DISABLED: 'Disabled looping as the queue is less than 15 seconds long.',

--- a/src/events/music/trackEnd.ts
+++ b/src/events/music/trackEnd.ts
@@ -1,8 +1,8 @@
 import type { QuaverQueue, QuaverSong } from '#src/lib/util/common.d.js';
 import {
-    MessageOptionsBuilderType,
     data,
     logger,
+    MessageOptionsBuilderType,
 } from '#src/lib/util/common.js';
 import { LoopType } from '@lavaclient/plugin-queue';
 import type { Collection, GuildMember, Snowflake } from 'discord.js';
@@ -14,28 +14,19 @@ export default {
     async execute(
         queue: QuaverQueue,
         track: QuaverSong,
-        reason:
-            | 'PLAYLIST_LOADED'
-            | 'TRACK_LOADED'
-            | 'SEARCH_RESULT'
-            | 'NO_MATCHES'
-            | 'LOAD_FAILED',
+        reason: 'cleanup' | 'finished' | 'loadFailed' | 'replaced' | 'stopped',
     ): Promise<void> {
         const { bot } = await import('#src/main.js');
         delete queue.player.skip;
-        if (reason === 'LOAD_FAILED') {
+        if (reason === 'loadFailed') {
             logger.warn({
-                message: `[G ${queue.player.id}] Track skipped with reason: ${reason}`,
+                message: `[G ${queue.player.id}] Track skipped as it failed to load`,
                 label: 'Quaver',
             });
             await queue.player.handler.locale(
                 'MUSIC.PLAYER.TRACK_SKIPPED_ERROR',
                 {
-                    vars: [
-                        escapeMarkdown(track.info.title),
-                        track.info.uri,
-                        reason,
-                    ],
+                    vars: [escapeMarkdown(track.info.title), track.info.uri],
                     type: MessageOptionsBuilderType.Warning,
                 },
             );


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [x] Critical
- [ ] High
- [ ] Medium
- [ ] Low

### Description
Please describe the changes.
Looks like there was a change made in lavaclient v5 to the trackEnd reason, which we didn't account for - this caused our code previously written for these issues to be ignored.
Updates typings, and updates the code to point to the new reason provided by lavaclient. Also updates the message displayed to users to be more specific.
Fixes #1374
Fixes #1375