### PR TITLE
refactor(scripts-jsonCommands): move promises[] to function scope

### DIFF
--- a/scripts/modules/jsonCommands.js
+++ b/scripts/modules/jsonCommands.js
@@ -35,13 +35,11 @@ async function loadCommandsFromPath(directoryPath) {
     return jsonCommands;
 }
 
-const promises = [
-    loadCommandsFromPath(
-        chatInputCommandsPath,
-    ),
-];
-
 export async function getJsonCommands() {
-    const jsonCommands = await Promise.all(promises);
+    const jsonCommands = await Promise.all([
+        loadCommandsFromPath(
+            chatInputCommandsPath,
+        ),
+    ]);
     return jsonCommands.flat();
 }


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description

Prior, `promises[]` was at module scope which made the order of operations unpredictable. In the context of its use, when `jsonCommands.js` is imported the commands then immediately get loaded (because it was at module scope) before the locales get mutated for getLocaleString to work properly. Closes #1373

Here's why the bug exists in `register-commands.x.js`
**Bugged behavior order:**
import `jsonCommands.js` -> loadCommandsFromPath` in promises[] -> export getJsonCommands
const localesMap = await getLocalesMap()
setLocales(localesMap)
const commands = await getJsonCommands() -> return result

**Corrected behavior order:**
import `jsonCommands.js` -> export getJsonCommands
const localesMap = await getLocalesMap()
setLocales(localesMap)
const commands = await getJsonCommands() -> loadCommandsFromPath in promises[] -> return result

Takeaway: imports that have code that run on them can have side-effects and can trigger code too early, before setup (setLocales in this context) is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined behind‑the‑scenes handling of command processing to improve maintainability while keeping functionality unchanged. Users will continue to enjoy the same smooth experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->