### PR TITLE
fix: update uri display

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -102,6 +102,7 @@ export default {
         },
         RESPONSE: {
             SUCCESS: 'Moved [**%1**](%2) `%3 -> %4`',
+            SUCCESS_DIRECT_LINK: 'Moved **%1** `%2 -> %3`',
             QUEUE_INSUFFICIENT_TRACKS: 'There aren\'t enough tracks in the queue to perform a move.',
             OUT_OF_RANGE: 'Your input was invalid.',
             MOVING_IN_PLACE: 'You can\'t move a track to the same position it is already in.',
@@ -166,8 +167,11 @@ export default {
         RESPONSE: {
             SUCCESS: {
                 DEFAULT: 'Removed [**%1**](%2)',
+                DEFAULT_DIRECT_LINK: 'Removed **%1**',
                 FORCED: 'Removed [**%1**](%2) by force',
+                FORCED_DIRECT_LINK: 'Removed **%1** by force',
                 MANAGER: 'Removed [**%1**](%2) by manager bypass',
+                MANAGER_DIRECT_LINK: 'Removed **%1** by manager bypass',
             },
             QUEUE_EMPTY: 'There are no tracks in the queue to remove.',
         },
@@ -284,12 +288,17 @@ export default {
         RESPONSE: {
             SUCCESS: {
                 DEFAULT: 'Skipped [**%1**](%2)',
+                DEFAULT_DIRECT_LINK: 'Skipped **%1**',
                 VOTED: 'Skipped [**%1**](%2) by voting',
+                VOTED_DIRECT_LINK: 'Skipped **%1** by voting',
                 FORCED: 'Skipped [**%1**](%2) by force',
+                FORCED_DIRECT_LINK: 'Skipped **%1** by force',
                 MANAGER: 'Skipped [**%1**](%2) by manager bypass',
+                MANAGER_DIRECT_LINK: 'Skipped **%1** by manager bypass',
             },
             VOTED: {
                 SUCCESS: 'Voted to skip [**%1**](%2) `[%3 / %4]`',
+                SUCCESS_DIRECT_LINK: 'Voted to skip **%1** `[%2 / %3]`',
                 STATE_UNCHANGED: 'You have already voted to skip this track.',
             },
         },

--- a/locales/en/music.js
+++ b/locales/en/music.js
@@ -30,7 +30,7 @@ export default {
             NOTHING: 'There is nothing playing right now.',
             NOW: {
                 SIMPLE: {
-                    TEXT: 'Now playing [**%1**](%2) `[%3]`',
+                    TEXT: 'Now playing %1 `[%2]`',
                     SOURCE: 'Source',
                 },
                 DETAILED: {

--- a/locales/en/music.js
+++ b/locales/en/music.js
@@ -23,6 +23,7 @@ export default {
     PLAYER: {
         FILTER_NOTE: 'This may take a few seconds to apply',
         TRACK_SKIPPED_ERROR: 'Skipped [**%1**](%2) as an error occurred while loading the track.',
+        TRACK_SKIPPED_ERROR_DIRECT_LINK: 'Skipped **%1** as an error occurred while loading the track.',
         QUEUE_CLEARED_ERROR: 'Cleared queue as an error occurred multiple times consecutively.',
         LOOP_TRACK_DISABLED: 'Disabled looping as the track is less than 15 seconds long.',
         LOOP_QUEUE_DISABLED: 'Disabled looping as the queue is less than 15 seconds long.',
@@ -30,7 +31,8 @@ export default {
             NOTHING: 'There is nothing playing right now.',
             NOW: {
                 SIMPLE: {
-                    TEXT: 'Now playing %1 `[%2]`',
+                    TEXT: 'Now playing [**%1**](%2) `[%3]`',
+                    TEXT_DIRECT_LINK: 'Now playing **%1** [%2]',
                     SOURCE: 'Source',
                 },
                 DETAILED: {
@@ -55,11 +57,15 @@ export default {
         TRACK_ADDED: {
             SINGLE: {
                 DEFAULT: 'Added [**%1**](%2) to queue',
+                DEFAULT_DIRECT_LINK: 'Added **%1** to queue',
                 INSERTED: 'Added [**%1**](%2) to start of queue',
+                INSERTED_DIRECT_LINK: 'Added **%1** to start of queue',
             },
             MULTIPLE: {
                 DEFAULT: 'Added **%1** tracks from [**%2**](%3) to queue',
+                DEFAULT_DIRECT_LINK: 'Added **%1** tracks from **%2** to queue',
                 INSERTED: 'Added **%1** tracks from [**%2**](%3) to start of queue',
+                INSERTED_DIRECT_LINK: 'Added **%1** tracks from **%2** to start of queue',
             },
         },
     },

--- a/src/commands/chatInputCommands/move.ts
+++ b/src/commands/chatInputCommands/move.ts
@@ -6,12 +6,12 @@ import type {
 import { MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getLocaleString } from '#src/lib/util/util.js';
+import { cleanURIForMarkdown, getLocaleString } from '#src/lib/util/util.js';
 import type {
     ChatInputCommandInteraction,
     SlashCommandIntegerOption,
 } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -87,10 +87,14 @@ export default {
             case PlayerResponse.Success: {
                 const track = player.queue.tracks[newPosition - 1];
                 await interaction.replyHandler.locale(
-                    'CMD.MOVE.RESPONSE.SUCCESS',
+                    track.info.title === track.info.uri
+                        ? 'CMD.MOVE.RESPONSE.SUCCESS_DIRECT_LINK'
+                        : 'CMD.MOVE.RESPONSE.SUCCESS',
                     {
                         vars: [
-                            escapeMarkdown(track.info.title),
+                            ...(track.info.title !== track.info.uri
+                                ? [cleanURIForMarkdown(track.info.title)]
+                                : []),
                             track.info.uri,
                             oldPosition.toString(),
                             newPosition.toString(),

--- a/src/commands/chatInputCommands/play.ts
+++ b/src/commands/chatInputCommands/play.ts
@@ -12,7 +12,11 @@ import {
     queryOverrides,
 } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
+import {
+    cleanURIForMarkdown,
+    getGuildLocaleString,
+    getLocaleString,
+} from '#src/lib/util/util.js';
 import type {
     ChatInputCommandInteraction,
     SlashCommandBooleanOption,
@@ -162,7 +166,13 @@ export default {
                 msg = insert
                     ? 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.INSERTED'
                     : 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.DEFAULT';
-                extras = [escapeMarkdown(track.info.title), track.info.uri];
+                if (track.info.title === track.info.uri) msg += '_DIRECT_LINK';
+                extras = [
+                    ...(track.info.title !== track.info.uri
+                        ? [cleanURIForMarkdown(track.info.title)]
+                        : []),
+                    track.info.uri,
+                ];
                 break;
             }
             case 'empty':

--- a/src/commands/chatInputCommands/playing.ts
+++ b/src/commands/chatInputCommands/playing.ts
@@ -5,11 +5,15 @@ import type {
 import { MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
+import {
+    cleanURIForMarkdown,
+    getGuildLocaleString,
+    getLocaleString,
+} from '#src/lib/util/util.js';
 import { LoopType } from '@lavaclient/plugin-queue';
 import { getBar, msToTime, msToTimeString } from '@zptxdev/zptx-lib';
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { escapeMarkdown, SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -68,9 +72,12 @@ export default {
         }
         if (player.queue.current.info.isStream) {
             await interaction.replyHandler.reply(
-                `**[${escapeMarkdown(player.queue.current.info.title)}](${
+                `${
+                    player.queue.current.info.title ===
                     player.queue.current.info.uri
-                })**\n🔴 **${await getGuildLocaleString(
+                        ? `**${player.queue.current.info.uri}**`
+                        : `[**${escapeMarkdown(cleanURIForMarkdown(player.queue.current.info.title))}**](${player.queue.current.info.uri})`
+                }\n🔴 **${await getGuildLocaleString(
                     interaction.guildId,
                     'MISC.LIVE',
                 )}** ${'▬'.repeat(10)}${player.paused ? ' ⏸️' : ''}${

--- a/src/commands/chatInputCommands/queue.ts
+++ b/src/commands/chatInputCommands/queue.ts
@@ -2,7 +2,11 @@ import type { QuaverInteraction } from '#src/lib/util/common.d.js';
 import { data, MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
+import {
+    cleanURIForMarkdown,
+    getGuildLocaleString,
+    getLocaleString,
+} from '#src/lib/util/util.js';
 import type { Song } from '@lavaclient/plugin-queue';
 import { msToTime, msToTimeString, paginate } from '@zptxdev/zptx-lib';
 import type { ChatInputCommandInteraction } from 'discord.js';
@@ -68,11 +72,11 @@ export default {
                                     'MISC.MORE_THAN_A_DAY',
                                 );
                             }
-                            return `\`${index + 1}.\` **[${escapeMarkdown(
-                                track.info.title,
-                            )}](${track.info.uri})** \`[${durationString}]\` <@${
-                                track.requesterId
-                            }>`;
+                            return `\`${index + 1}.\` ${
+                                track.info.title === track.info.uri
+                                    ? `**${track.info.uri}**`
+                                    : `[**${escapeMarkdown(cleanURIForMarkdown(track.info.title))}**](${track.info.uri})`
+                            } \`[${durationString}]\` <@${track.requesterId}>`;
                         })
                         .join('\n'),
                 )

--- a/src/commands/chatInputCommands/remove.ts
+++ b/src/commands/chatInputCommands/remove.ts
@@ -7,16 +7,17 @@ import { MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
-    RequesterStatus,
+    cleanURIForMarkdown,
     getLocaleString,
     getRequesterStatus,
+    RequesterStatus,
 } from '#src/lib/util/util.js';
 import type {
     ChatInputCommandInteraction,
     GuildMember,
     SlashCommandIntegerOption,
 } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -86,21 +87,24 @@ export default {
                     type: MessageOptionsBuilderType.Error,
                 });
                 return;
-            default:
-                await interaction.replyHandler.locale(
+            default: {
+                let locale =
                     requesterStatus === RequesterStatus.Requester
                         ? 'CMD.REMOVE.RESPONSE.SUCCESS.DEFAULT'
                         : requesterStatus === RequesterStatus.ManagerBypass
                           ? 'CMD.REMOVE.RESPONSE.SUCCESS.MANAGER'
-                          : 'CMD.REMOVE.RESPONSE.SUCCESS.FORCED',
-                    {
-                        vars: [
-                            escapeMarkdown(track.info.title),
-                            track.info.uri,
-                        ],
-                        type: MessageOptionsBuilderType.Success,
-                    },
-                );
+                          : 'CMD.REMOVE.RESPONSE.SUCCESS.FORCED';
+                if (track.info.title === track.info.uri) {locale += '_DIRECT_LINK';}
+                await interaction.replyHandler.locale(locale, {
+                    vars: [
+                        ...(track.info.title !== track.info.uri
+                            ? [cleanURIForMarkdown(track.info.title)]
+                            : []),
+                        track.info.uri,
+                    ],
+                    type: MessageOptionsBuilderType.Success,
+                });
+            }
         }
     },
 };

--- a/src/commands/chatInputCommands/search.ts
+++ b/src/commands/chatInputCommands/search.ts
@@ -9,6 +9,7 @@ import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
     buildMessageOptions,
+    cleanURIForMarkdown,
     getGuildLocaleString,
     getLocaleString,
 } from '#src/lib/util/util.js';
@@ -140,9 +141,11 @@ export default {
                                 .padStart(
                                     tracks.length.toString().length,
                                     ' ',
-                                )}.\` **[${escapeMarkdown(track.info.title)}](${
-                                track.info.uri
-                            })** \`[${durationString}]\``;
+                                )}.\` ${
+                                track.info.title === track.info.uri
+                                    ? `**${track.info.uri}**`
+                                    : `[**${escapeMarkdown(cleanURIForMarkdown(track.info.title))}**](${track.info.uri})`
+                            } \`[${durationString}]\``;
                         })
                         .join('\n'),
                 )

--- a/src/components/buttons/queue.ts
+++ b/src/components/buttons/queue.ts
@@ -2,7 +2,11 @@ import { ForceType } from '#src/lib/ReplyHandler.js';
 import type { QuaverInteraction } from '#src/lib/util/common.d.js';
 import { data, MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
+import {
+    cleanURIForMarkdown,
+    getGuildLocaleString,
+    getLocaleString,
+} from '#src/lib/util/util.js';
 import type { Song } from '@lavaclient/plugin-queue';
 import { msToTime, msToTimeString, paginate } from '@zptxdev/zptx-lib';
 import type {
@@ -101,14 +105,16 @@ export default {
                                 'MISC.MORE_THAN_A_DAY',
                             );
                         }
+                        const uri =
+                            track.info.title === track.info.uri
+                                ? `**${track.info.uri}**`
+                                : `[**${escapeMarkdown(cleanURIForMarkdown(track.info.title))}**](${track.info.uri})`;
                         return `\`${(firstIndex + index)
                             .toString()
                             .padStart(
                                 largestIndexSize,
                                 ' ',
-                            )}.\` **[${escapeMarkdown(track.info.title)}](${
-                            track.info.uri
-                        })** \`[${durationString}]\` <@${track.requesterId}>`;
+                            )}.\` ${uri} \`[${durationString}]\` <@${track.requesterId}>`;
                     })
                     .join('\n'),
             )

--- a/src/components/buttons/search.ts
+++ b/src/components/buttons/search.ts
@@ -16,6 +16,7 @@ import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
     buildMessageOptions,
+    cleanURIForMarkdown,
     getFailedChecks,
     getGuildLocaleString,
     getLocaleString,
@@ -304,14 +305,16 @@ export default {
                                 'MISC.MORE_THAN_A_DAY',
                             );
                         }
+                        const uri =
+                            track.info.title === track.info.uri
+                                ? `**${track.info.uri}**`
+                                : `[**${escapeMarkdown(cleanURIForMarkdown(track.info.title))}**](${track.info.uri})`;
                         return `\`${(firstIndex + index)
                             .toString()
                             .padStart(
                                 largestIndexSize,
                                 ' ',
-                            )}.\` **[${escapeMarkdown(track.info.title)}](${
-                            track.info.uri
-                        })** \`[${durationString}]\``;
+                            )}.\` ${uri} \`[${durationString}]\``;
                     })
                     .join('\n'),
             )

--- a/src/components/modalSubmits/queue.ts
+++ b/src/components/modalSubmits/queue.ts
@@ -2,7 +2,11 @@ import { ForceType } from '#src/lib/ReplyHandler.js';
 import type { QuaverInteraction } from '#src/lib/util/common.d.js';
 import { data, MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { settings } from '#src/lib/util/settings.js';
-import { getGuildLocaleString, getLocaleString } from '#src/lib/util/util.js';
+import {
+    cleanURIForMarkdown,
+    getGuildLocaleString,
+    getLocaleString,
+} from '#src/lib/util/util.js';
 import type { Song } from '@lavaclient/plugin-queue';
 import { msToTime, msToTimeString, paginate } from '@zptxdev/zptx-lib';
 import type {
@@ -91,12 +95,11 @@ export default {
                         }
                         return `\`${(firstIndex + index)
                             .toString()
-                            .padStart(
-                                largestIndexSize,
-                                ' ',
-                            )}.\` **[${escapeMarkdown(track.info.title)}](${
-                            track.info.uri
-                        })** \`[${durationString}]\` <@${track.requesterId}>`;
+                            .padStart(largestIndexSize, ' ')}.\` ${
+                            track.info.title === track.info.uri
+                                ? `**${track.info.uri}**`
+                                : `[**${escapeMarkdown(cleanURIForMarkdown(track.info.title))}**](${track.info.uri})`
+                        } \`[${durationString}]\` <@${track.requesterId}>`;
                     })
                     .join('\n'),
             )

--- a/src/events/music/trackEnd.ts
+++ b/src/events/music/trackEnd.ts
@@ -6,7 +6,7 @@ import {
 } from '#src/lib/util/common.js';
 import { LoopType } from '@lavaclient/plugin-queue';
 import type { Collection, GuildMember, Snowflake } from 'discord.js';
-import { escapeMarkdown } from 'discord.js';
+import { cleanURIForMarkdown } from '#src/lib/util/util.js';
 
 export default {
     name: 'trackEnd',
@@ -24,9 +24,16 @@ export default {
                 label: 'Quaver',
             });
             await queue.player.handler.locale(
-                'MUSIC.PLAYER.TRACK_SKIPPED_ERROR',
+                track.info.title === track.info.uri
+                    ? 'MUSIC.PLAYER.TRACK_SKIPPED_ERROR_DIRECT_LINK'
+                    : 'MUSIC.PLAYER.TRACK_SKIPPED_ERROR',
                 {
-                    vars: [escapeMarkdown(track.info.title), track.info.uri],
+                    vars: [
+                        ...(track.info.title !== track.info.uri
+                            ? [cleanURIForMarkdown(track.info.title)]
+                            : []),
+                        track.info.uri,
+                    ],
                     type: MessageOptionsBuilderType.Warning,
                 },
             );

--- a/src/events/music/trackStart.ts
+++ b/src/events/music/trackStart.ts
@@ -15,7 +15,6 @@ import {
     ButtonBuilder,
     ButtonStyle,
     EmbedBuilder,
-    escapeMarkdown,
 } from 'discord.js';
 
 export default {
@@ -88,14 +87,19 @@ export default {
             settings.emojis?.[
                 track.info.sourceName as keyof typeof settings.emojis
             ] ?? '';
+        let uri = `[**${track.info.title}**](${track.info.uri})`;
+        if (track.info.uri === track.info.title) {
+            uri = `**${track.info.uri}**`;
+        } else if (track.info.title.match(/^(https?:\/\/.*?)(\/)?$/)) {
+            uri = `[**${track.info.title.replace(/^https?:\/\//, '').replace(/\/$/, '')}**](${track.info.uri})`;
+        }
         switch (format) {
-            case 'simple':
+            case 'simple': {
                 await queue.player.handler.send(
                     `${getLocaleString(
                         guildLocaleCode,
                         'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                        escapeMarkdown(track.info.title),
-                        track.info.uri,
+                        uri,
                         durationString,
                     )}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, `MISC.SOURCES.${track.info.sourceName.toUpperCase()}`)}** ─ ${getLocaleString(
                         guildLocaleCode,
@@ -128,6 +132,7 @@ export default {
                     },
                 );
                 break;
+            }
             case 'detailed':
                 await queue.player.handler.send(
                     new EmbedBuilder()
@@ -137,9 +142,7 @@ export default {
                                 'MUSIC.PLAYER.PLAYING.NOW.DETAILED.TITLE',
                             ),
                         )
-                        .setDescription(
-                            `**[${escapeMarkdown(track.info.title)}](${track.info.uri})**`,
-                        )
+                        .setDescription(uri)
                         .addFields([
                             {
                                 name: getLocaleString(

--- a/src/events/music/trackStart.ts
+++ b/src/events/music/trackStart.ts
@@ -94,7 +94,7 @@ export default {
             uri = `[**${track.info.title.replace(/^https?:\/\//, '').replace(/\/$/, '')}**](${track.info.uri})`;
         }
         switch (format) {
-            case 'simple': {
+            case 'simple':
                 await queue.player.handler.send(
                     `${getLocaleString(
                         guildLocaleCode,
@@ -132,7 +132,6 @@ export default {
                     },
                 );
                 break;
-            }
             case 'detailed':
                 await queue.player.handler.send(
                     new EmbedBuilder()

--- a/src/events/music/trackStart.ts
+++ b/src/events/music/trackStart.ts
@@ -2,6 +2,7 @@ import type { QuaverQueue, QuaverSong } from '#src/lib/util/common.d.js';
 import { data, logger } from '#src/lib/util/common.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
+    cleanURIForMarkdown,
     formatResponse,
     generateEmbedFieldsFromLyrics,
     getGuildFeatureWhitelisted,
@@ -87,21 +88,21 @@ export default {
             settings.emojis?.[
                 track.info.sourceName as keyof typeof settings.emojis
             ] ?? '';
-        let uri = `[**${track.info.title}**](${track.info.uri})`;
-        if (track.info.uri === track.info.title) {
-            uri = `**${track.info.uri}**`;
-        } else if (track.info.title.match(/^(https?:\/\/.*?)(\/)?$/)) {
-            uri = `[**${track.info.title.replace(/^https?:\/\//, '').replace(/\/$/, '')}**](${track.info.uri})`;
-        }
+        const uri = getLocaleString(
+            guildLocaleCode,
+            track.info.title === track.info.uri
+                ? 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT_DIRECT_LINK'
+                : 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
+            ...(track.info.title !== track.info.uri
+                ? [cleanURIForMarkdown(track.info.title)]
+                : []),
+            track.info.uri,
+            durationString,
+        );
         switch (format) {
             case 'simple':
                 await queue.player.handler.send(
-                    `${getLocaleString(
-                        guildLocaleCode,
-                        'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                        uri,
-                        durationString,
-                    )}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, `MISC.SOURCES.${track.info.sourceName.toUpperCase()}`)}** ─ ${getLocaleString(
+                    `${uri}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, `MISC.SOURCES.${track.info.sourceName.toUpperCase()}`)}** ─ ${getLocaleString(
                         guildLocaleCode,
                         'MISC.ADDED_BY',
                         track.requesterId,

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -702,13 +702,10 @@ export async function buildSettingsPage(
                                   `${getLocaleString(
                                       guildLocaleCode,
                                       'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                                      escapeMarkdown(
-                                          getLocaleString(
-                                              guildLocaleCode,
-                                              'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE',
-                                          ),
-                                      ),
-                                      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                                      `[**${getLocaleString(
+                                          guildLocaleCode,
+                                          'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE',
+                                      )}**](https://www.youtube.com/watch?v=dQw4w9WgXcQ)`,
                                       '4:20',
                                   )}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, 'MISC.SOURCES.YOUTUBE')}** ─ ${getLocaleString(
                                       guildLocaleCode,

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -702,10 +702,11 @@ export async function buildSettingsPage(
                                   `${getLocaleString(
                                       guildLocaleCode,
                                       'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                                      `[**${getLocaleString(
+                                      getLocaleString(
                                           guildLocaleCode,
                                           'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE',
-                                      )}**](https://www.youtube.com/watch?v=dQw4w9WgXcQ)`,
+                                      ),
+                                      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
                                       '4:20',
                                   )}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, 'MISC.SOURCES.YOUTUBE')}** ─ ${getLocaleString(
                                       guildLocaleCode,
@@ -915,4 +916,15 @@ export function updateAcceptableSources(
     for (const [key, value] of Object.entries(sourceManagers)) {
         acceptableSources[key] = value;
     }
+}
+
+/**
+ * Cleans a URI for use in markdown.
+ * @param uri - The URI to clean.
+ * @returns The cleaned URI. If not a valid URI, returns the input.
+ */
+export function cleanURIForMarkdown(uri: string): string {
+    return uri.match(/^(https?:\/\/.*?)(\/)?$/)
+        ? uri.replace(/^https?:\/\//, '').replace(/\/$/, '')
+        : uri;
 }


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Possibly fixes issue where Discord's markdown won't resolve links
Needs testing
Fixes #1355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Added alternative message formats for music playback and queue notifications that display track titles in bold without hyperlinks for clearer readability.
- **Refactor**
	- Unified and enhanced the formatting of track titles and URIs across player messages, commands, and UI components, conditionally removing markdown links when titles match URIs.
- **Chores**
	- Introduced a utility to clean URIs for markdown use, improving message consistency and simplifying localization key selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->