### PR TITLE
refactor: remove unnecessary escapeMarkdown usages

### DIFF
--- a/src/commands/chatInputCommands/move.ts
+++ b/src/commands/chatInputCommands/move.ts
@@ -11,7 +11,7 @@ import type {
     ChatInputCommandInteraction,
     SlashCommandIntegerOption,
 } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -90,7 +90,7 @@ export default {
                     'CMD.MOVE.RESPONSE.SUCCESS',
                     {
                         vars: [
-                            escapeMarkdown(track.info.title),
+                            track.info.title,
                             track.info.uri,
                             oldPosition.toString(),
                             newPosition.toString(),

--- a/src/commands/chatInputCommands/play.ts
+++ b/src/commands/chatInputCommands/play.ts
@@ -21,7 +21,6 @@ import type {
 import {
     ChannelType,
     EmbedBuilder,
-    escapeMarkdown,
     GuildMember,
     PermissionsBitField,
     SlashCommandBuilder,
@@ -150,7 +149,7 @@ export default {
                     : 'MUSIC.QUEUE.TRACK_ADDED.MULTIPLE.DEFAULT';
                 extras = [
                     tracks.length.toString(),
-                    escapeMarkdown(result.data.info.name),
+                    result.data.info.name,
                     query,
                 ];
                 break;
@@ -162,7 +161,7 @@ export default {
                 msg = insert
                     ? 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.INSERTED'
                     : 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.DEFAULT';
-                extras = [escapeMarkdown(track.info.title), track.info.uri];
+                extras = [track.info.title, track.info.uri];
                 break;
             }
             case 'empty':

--- a/src/commands/chatInputCommands/remove.ts
+++ b/src/commands/chatInputCommands/remove.ts
@@ -7,16 +7,16 @@ import { MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
-    RequesterStatus,
     getLocaleString,
     getRequesterStatus,
+    RequesterStatus,
 } from '#src/lib/util/util.js';
 import type {
     ChatInputCommandInteraction,
     GuildMember,
     SlashCommandIntegerOption,
 } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -94,10 +94,7 @@ export default {
                           ? 'CMD.REMOVE.RESPONSE.SUCCESS.MANAGER'
                           : 'CMD.REMOVE.RESPONSE.SUCCESS.FORCED',
                     {
-                        vars: [
-                            escapeMarkdown(track.info.title),
-                            track.info.uri,
-                        ],
+                        vars: [track.info.title, track.info.uri],
                         type: MessageOptionsBuilderType.Success,
                     },
                 );

--- a/src/commands/chatInputCommands/skip.ts
+++ b/src/commands/chatInputCommands/skip.ts
@@ -7,13 +7,13 @@ import { MessageOptionsBuilderType } from '#src/lib/util/common.js';
 import { Check } from '#src/lib/util/constants.js';
 import { settings } from '#src/lib/util/settings.js';
 import {
-    RequesterStatus,
     getGuildLocaleString,
     getLocaleString,
     getRequesterStatus,
+    RequesterStatus,
 } from '#src/lib/util/util.js';
 import type { ChatInputCommandInteraction, GuildMember } from 'discord.js';
-import { SlashCommandBuilder, escapeMarkdown } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 
 export default {
     data: new SlashCommandBuilder()
@@ -83,7 +83,7 @@ export default {
                             `${await getGuildLocaleString(
                                 interaction.guildId,
                                 'CMD.SKIP.RESPONSE.SUCCESS.VOTED',
-                                escapeMarkdown(track.info.title),
+                                track.info.title,
                                 track.info.uri,
                             )}\n${await getGuildLocaleString(
                                 interaction.guildId,
@@ -99,7 +99,7 @@ export default {
                 'CMD.SKIP.RESPONSE.VOTED.SUCCESS',
                 {
                     vars: [
-                        escapeMarkdown(track.info.title),
+                        track.info.title,
                         track.info.uri,
                         skip.users.length.toString(),
                         skip.required.toString(),
@@ -126,7 +126,7 @@ export default {
                             : requesterStatus === RequesterStatus.ManagerBypass
                               ? 'CMD.SKIP.RESPONSE.SUCCESS.MANAGER'
                               : 'CMD.SKIP.RESPONSE.SUCCESS.FORCED',
-                        escapeMarkdown(track.info.title),
+                        track.info.title,
                         track.info.uri,
                     )}${
                         requesterStatus !== RequesterStatus.Requester

--- a/src/components/buttons/search.ts
+++ b/src/components/buttons/search.ts
@@ -138,7 +138,7 @@ export default {
             if (resolvedTracks.length === 1) {
                 msg = 'MUSIC.QUEUE.TRACK_ADDED.SINGLE.DEFAULT';
                 extras = [
-                    escapeMarkdown(resolvedTracks[0].info.title),
+                    resolvedTracks[0].info.title,
                     resolvedTracks[0].info.uri,
                 ];
             } else {

--- a/src/events/music/trackEnd.ts
+++ b/src/events/music/trackEnd.ts
@@ -6,7 +6,6 @@ import {
 } from '#src/lib/util/common.js';
 import { LoopType } from '@lavaclient/plugin-queue';
 import type { Collection, GuildMember, Snowflake } from 'discord.js';
-import { escapeMarkdown } from 'discord.js';
 
 export default {
     name: 'trackEnd',
@@ -26,7 +25,7 @@ export default {
             await queue.player.handler.locale(
                 'MUSIC.PLAYER.TRACK_SKIPPED_ERROR',
                 {
-                    vars: [escapeMarkdown(track.info.title), track.info.uri],
+                    vars: [track.info.title, track.info.uri],
                     type: MessageOptionsBuilderType.Warning,
                 },
             );

--- a/src/events/music/trackStart.ts
+++ b/src/events/music/trackStart.ts
@@ -94,7 +94,7 @@ export default {
                     `${getLocaleString(
                         guildLocaleCode,
                         'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                        escapeMarkdown(track.info.title),
+                        track.info.title,
                         track.info.uri,
                         durationString,
                     )}\n${getLocaleString(guildLocaleCode, 'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.SOURCE')}: ${emoji ? `${emoji} ` : ''}**${getLocaleString(guildLocaleCode, `MISC.SOURCES.${track.info.sourceName.toUpperCase()}`)}** ─ ${getLocaleString(

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -702,11 +702,9 @@ export async function buildSettingsPage(
                                   `${getLocaleString(
                                       guildLocaleCode,
                                       'MUSIC.PLAYER.PLAYING.NOW.SIMPLE.TEXT',
-                                      escapeMarkdown(
-                                          getLocaleString(
-                                              guildLocaleCode,
-                                              'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE',
-                                          ),
+                                      getLocaleString(
+                                          guildLocaleCode,
+                                          'CMD.SETTINGS.MISC.FORMAT.EXAMPLE.SIMPLE',
                                       ),
                                       'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
                                       '4:20',


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description
Please describe the changes.
Resolves #1389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Track and playlist titles are now displayed without escaping markdown characters in various messages and responses, resulting in titles appearing exactly as entered.
- **Bug Fixes**
  - Improved consistency in how track titles are shown across commands and messages by removing unnecessary markdown escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->