### PR TITLE
refactor(events-music): use correct event name

### DIFF
--- a/src/events/music/ready.ts
+++ b/src/events/music/ready.ts
@@ -21,7 +21,7 @@ async function readPlayerStates(): Promise<Record<string, QuaverPlayerJSON>> {
 }
 
 export default {
-    name: 'connected',
+    name: 'ready',
     once: false,
     async execute(): Promise<void> {
         const { client } = await import('#src/main');


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Is your code documented, if applicable? (Check if not applicable)
- [ ] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Priority
- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description

Might've overlooked? With fresh eyes, I don't know the reasoning behind having lavaclient's ready.ts event module having `name` set to `connected`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal event handling configuration to improve naming clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->