### PR TITLE
feat: pause alone in 24/7 option

### DIFF
--- a/locales/en/cmd.js
+++ b/locales/en/cmd.js
@@ -273,6 +273,10 @@ export default {
                         DESCRIPTION: 'Whether to send "Now playing" messages in 24/7 mode.',
                         NAME: 'Notify in 24/7 mode',
                     },
+                    PAUSEALONE247: {
+                        DESCRIPTION: 'Whether to pause playback when alone in voice channel in 24/7 mode.',
+                        NAME: 'Pause alone in 24/7 mode',
+                    },
                     SMARTQUEUE: {
                         DESCRIPTION: 'Sorts the queue to alternate between requesters.',
                         NAME: 'Smart Queue',

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -1,6 +1,6 @@
 import { MessageOptionsBuilderType, type QuaverClient } from '#src/lib';
 import { EventHandler } from '#src/lib/builders';
-import { QuaverGuild, type Initialized } from '#src/lib/guild';
+import { type Initialized, QuaverGuild } from '#src/lib/guild';
 import { logger } from '#src/lib/logger';
 import type { QuaverPlayer } from '#src/lib/music';
 import {
@@ -91,7 +91,7 @@ async function onChannelEmpty(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
     isOldQuaverStateUpdate: boolean,
-    isGuildStayEnabled: boolean | unknown,
+    isGuildStayEnabled: boolean | undefined,
 ): Promise<void> {
     const guild = await QuaverGuild.wrap(player.guild);
     const isPlayerIdle =
@@ -152,7 +152,7 @@ async function onChannelJoinOrMove(
     io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, unknown>,
     player: QuaverPlayer,
     newState: VoiceState,
-    isGuildStayEnabled: boolean | unknown,
+    isGuildStayEnabled: boolean | undefined,
     isOldQuaverStateUpdate: boolean,
 ): Promise<void> {
     const guild = await QuaverGuild.wrap(player.guild);
@@ -162,7 +162,10 @@ async function onChannelJoinOrMove(
     }
     // In this context newState#channel is always defined for join/move states, so optional chaining is unnecessary
     const hasNewChannelUsers = newState.channel.members.filter(isUser).size > 0;
-    if (hasNewChannelUsers && (player.timeout.pause || player.timeout.pausedAlone)) {
+    if (
+        hasNewChannelUsers &&
+        (player.timeout.pause || player.timeout.pausedAlone)
+    ) {
         await resumeChannelSession(io, player);
     }
     // To prevent Quaver from handling a channel that still has users or the guild's stay feature is enabled, do not handle the channel
@@ -183,7 +186,7 @@ async function handleQuaverDisconnection(
     guild: QuaverGuild<Initialized> & Guild,
     player: QuaverPlayer,
     oldChannelId: string | null,
-    isGuildStayEnabled: boolean | unknown,
+    isGuildStayEnabled: boolean | undefined,
 ): Promise<void> {
     // To ensure Quaver does not persist in an inactive session, disable stay feature for this guild
     if (isGuildStayEnabled) {
@@ -204,7 +207,7 @@ async function handleQuaverJoinOrMove(
     guild: QuaverGuild<Initialized> & Guild,
     player: QuaverPlayer,
     newState: VoiceState,
-    isGuildStayEnabled: boolean | unknown,
+    isGuildStayEnabled: boolean | undefined,
     isOldQuaverStateUpdate: boolean,
     oldClientUserId: string,
 ): Promise<void> {
@@ -214,14 +217,17 @@ async function handleQuaverJoinOrMove(
     const newChannelType = newChannel?.type;
 
     // To keep the dashboard updated with the latest session details, emit channel events for this guild
-    guild.sendWebUpdate('textChannelUpdate', player.queue.channel.name);
+    guild.sendWebUpdate('textChannelUpdate', player.queue.channel?.name);
     guild.sendWebUpdate('channelUpdate', newChannel?.name);
 
     // For type consistency, create an empty map for unhandled states
     const channelPermissions = guild.channels.cache
         .get(newChannelId)
         ?.permissionsFor(oldClientUserId);
-    if (!channelPermissions) return;
+    if (!channelPermissions) {
+        await player.disconnect();
+        return;
+    }
 
     const hasBasicChannelPermissions = channelPermissions.has(
         new PermissionsBitField([
@@ -251,10 +257,7 @@ async function handleQuaverJoinOrMove(
         return;
     }
 
-    if (
-        newChannelType === ChannelType.GuildStageVoice &&
-        newState.suppress
-    ) {
+    if (newChannelType === ChannelType.GuildStageVoice) {
         // To prevent permission errors, properly disconnect Quaver
         if (!hasBasicChannelPermissions) {
             await player.sendMessage(
@@ -272,30 +275,30 @@ async function handleQuaverJoinOrMove(
         }
         if (!hasStageModerator) {
             await player.sendMessage(
-                guild.locale(
-                    'MUSIC.SESSION_ENDED.FORCED.STAGE_NOT_MODERATOR',
-                ),
+                guild.locale('MUSIC.SESSION_ENDED.FORCED.STAGE_NOT_MODERATOR'),
                 { type: MessageOptionsBuilderType.Warning },
             );
             await player.disconnect();
             return;
         }
-        // To avoid errors from recreating a stage instance, only create one if it doesn't already exist
-        if (newChannel && !newChannel.stageInstance) {
-            try {
-                await newChannel.createStageInstance({
-                    topic: guild.locale('MISC.STAGE_TOPIC'),
-                    privacyLevel: StageInstancePrivacyLevel.GuildOnly,
-                });
-            } catch (error) {
-                if (error instanceof Error) {
-                    logger.error(`${error.message}\n${error.stack}`);
+        if (newState.suppress) {
+            // To avoid errors from recreating a stage instance, only create one if it doesn't already exist
+            if (newChannel && !newChannel.stageInstance) {
+                try {
+                    await newChannel.createStageInstance({
+                        topic: guild.locale('MISC.STAGE_TOPIC'),
+                        privacyLevel: StageInstancePrivacyLevel.GuildOnly,
+                    });
+                } catch (error) {
+                    if (error instanceof Error) {
+                        logger.error(`${error.message}\n${error.stack}`);
+                    }
                 }
             }
+            // To prevent a regression bug in which Quaver remains silent in stage channels, unsuppress Quaver after stage instance creation
+            // Also handles unsuppressing Quaver mid-track as suppress state updates were intentionally written not to be ignored by Quaver
+            await newState.setSuppressed(false);
         }
-        // To prevent a regression bug in which Quaver remains silent in stage channels, unsuppress Quaver after stage instance creation
-        // Also handles unsuppressing Quaver mid-track as suppress state updates were intentionally written not to be ignored by Quaver
-        await newState.setSuppressed(false);
         await onChannelJoinOrMove(
             guild.client.io,
             player,
@@ -311,7 +314,7 @@ async function handleUserVoiceStateUpdate(
     newState: VoiceState,
     guild: QuaverGuild<Initialized> & Guild,
     player: QuaverPlayer,
-    isGuildStayEnabled: boolean | unknown,
+    isGuildStayEnabled: boolean | undefined,
     isOldQuaverStateUpdate: boolean,
 ): Promise<void> {
     const newChannelId = newState.channelId;
@@ -327,20 +330,21 @@ async function handleUserVoiceStateUpdate(
     }
 
     const isUserLeaveOrMoveState = oldChannelId === player.voice.channelId;
-    const pauseAlone =
-        (await guild.settings.get<boolean>('pausealone247')) ?? false;
     // Since the last user left or moved out from Quaver's channel, handle the empty channel
     if (
         isUserLeaveOrMoveState &&
-        oldState.channel?.members.filter(isUser).size < 1 &&
-        (!isGuildStayEnabled || pauseAlone)
+        oldState.channel?.members.filter(isUser).size < 1
     ) {
-        await onChannelEmpty(
-            guild.client.io,
-            player,
-            isOldQuaverStateUpdate,
-            isGuildStayEnabled,
-        );
+        const pauseAlone =
+            (await guild.settings.get<boolean>('pausealone247')) ?? false;
+        if (!isGuildStayEnabled || pauseAlone) {
+            await onChannelEmpty(
+                guild.client.io,
+                player,
+                isOldQuaverStateUpdate,
+                isGuildStayEnabled,
+            );
+        }
     }
 }
 

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -1,11 +1,12 @@
 import { MessageOptionsBuilderType, type QuaverClient } from '#src/lib';
 import { EventHandler } from '#src/lib/builders';
-import { QuaverGuild } from '#src/lib/guild';
+import { QuaverGuild, type Initialized } from '#src/lib/guild';
 import { logger } from '#src/lib/logger';
 import type { QuaverPlayer } from '#src/lib/music';
 import {
     ChannelType,
     ContainerBuilder,
+    type Guild,
     type GuildMember,
     PermissionsBitField,
     StageInstancePrivacyLevel,
@@ -77,6 +78,7 @@ async function resumeChannelSession(
     await player.resume();
     clearTimeout(player.timeout.pause);
     player.timeout.pause = null;
+    player.timeout.pausedAlone = false;
     guild.sendWebUpdate('pauseUpdate', player.paused);
     guild.sendWebUpdate('pauseTimeoutUpdate', !!player.timeout.pause);
     await player.sendMessage(guild.locale('MUSIC.DISCONNECT.ALONE.RESUMING'), {
@@ -99,6 +101,9 @@ async function onChannelEmpty(
         await guild.settings.set('stay.enabled', false);
     }
     if (isPlayerIdle && player.voice.channelId) {
+        if (isGuildStayEnabled) {
+            return;
+        }
         logger.info(`[G ${guild.id}] Disconnecting (alone)`);
         await player.sendMessage(
             guild.locale(
@@ -115,8 +120,29 @@ async function onChannelEmpty(
     if (
         player.timeout.standard ||
         player.timeout.pause ||
+        player.timeout.pausedAlone ||
         !player.voice.channelId
     ) {
+        return;
+    }
+    if (isGuildStayEnabled) {
+        if (player.paused) {
+            return;
+        }
+        await player.pause();
+        guild.sendWebUpdate('pauseUpdate', player.paused);
+        player.timeout.pausedAlone = true;
+        await player.sendMessage(
+            new ContainerBuilder().addTextDisplayComponents(
+                guild.builders.textDisplayLocale(
+                    'MUSIC.DISCONNECT.ALONE.WARNING',
+                ),
+                guild.builders.textDisplayLocale(
+                    'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME',
+                ),
+            ),
+            { type: MessageOptionsBuilderType.Warning },
+        );
         return;
     }
     await pauseChannelSession(io, player);
@@ -136,11 +162,13 @@ async function onChannelJoinOrMove(
     }
     // In this context newState#channel is always defined for join/move states, so optional chaining is unnecessary
     const hasNewChannelUsers = newState.channel.members.filter(isUser).size > 0;
-    if (hasNewChannelUsers && player.timeout.pause) {
+    if (hasNewChannelUsers && (player.timeout.pause || player.timeout.pausedAlone)) {
         await resumeChannelSession(io, player);
     }
     // To prevent Quaver from handling a channel that still has users or the guild's stay feature is enabled, do not handle the channel
-    if (hasNewChannelUsers || isGuildStayEnabled) {
+    const pauseAlone =
+        (await guild.settings.get<boolean>('pausealone247')) ?? false;
+    if (hasNewChannelUsers || (isGuildStayEnabled && !pauseAlone)) {
         return;
     }
     await onChannelEmpty(
@@ -149,6 +177,171 @@ async function onChannelJoinOrMove(
         isOldQuaverStateUpdate,
         isGuildStayEnabled,
     );
+}
+
+async function handleQuaverDisconnection(
+    guild: QuaverGuild<Initialized> & Guild,
+    player: QuaverPlayer,
+    oldChannelId: string | null,
+    isGuildStayEnabled: boolean | unknown,
+): Promise<void> {
+    // To ensure Quaver does not persist in an inactive session, disable stay feature for this guild
+    if (isGuildStayEnabled) {
+        await guild.settings.set('stay.enabled', false);
+    }
+    // To reset states, properly handle disconnection
+    if (!player.voice.channelId) {
+        logger.info(`[G ${guild.id}] Cleaning up (disconnected)`);
+        await player.sendMessage(
+            guild.locale('MUSIC.SESSION_ENDED.FORCED.DISCONNECTED'),
+            { type: MessageOptionsBuilderType.Warning },
+        );
+        await player.disconnect(oldChannelId ?? undefined);
+    }
+}
+
+async function handleQuaverJoinOrMove(
+    guild: QuaverGuild<Initialized> & Guild,
+    player: QuaverPlayer,
+    newState: VoiceState,
+    isGuildStayEnabled: boolean | unknown,
+    isOldQuaverStateUpdate: boolean,
+    oldClientUserId: string,
+): Promise<void> {
+    const newChannelId = newState.channelId;
+    if (!newChannelId) return;
+    const newChannel = newState.channel;
+    const newChannelType = newChannel?.type;
+
+    // To keep the dashboard updated with the latest session details, emit channel events for this guild
+    guild.sendWebUpdate('textChannelUpdate', player.queue.channel.name);
+    guild.sendWebUpdate('channelUpdate', newChannel?.name);
+
+    // For type consistency, create an empty map for unhandled states
+    const channelPermissions = guild.channels.cache
+        .get(newChannelId)
+        ?.permissionsFor(oldClientUserId);
+    if (!channelPermissions) return;
+
+    const hasBasicChannelPermissions = channelPermissions.has(
+        new PermissionsBitField([
+            PermissionsBitField.Flags.ViewChannel,
+            PermissionsBitField.Flags.Connect,
+            PermissionsBitField.Flags.Speak,
+        ]),
+    );
+
+    if (newChannelType === ChannelType.GuildVoice) {
+        // To prevent permission errors, properly disconnect Quaver
+        if (!hasBasicChannelPermissions) {
+            await player.sendMessage(
+                guild.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC'),
+                { type: MessageOptionsBuilderType.Error },
+            );
+            await player.disconnect();
+            return;
+        }
+        await onChannelJoinOrMove(
+            guild.client.io,
+            player,
+            newState,
+            isGuildStayEnabled,
+            isOldQuaverStateUpdate,
+        );
+        return;
+    }
+
+    if (
+        newChannelType === ChannelType.GuildStageVoice &&
+        newState.suppress
+    ) {
+        // To prevent permission errors, properly disconnect Quaver
+        if (!hasBasicChannelPermissions) {
+            await player.sendMessage(
+                guild.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC'),
+                { type: MessageOptionsBuilderType.Error },
+            );
+            await player.disconnect();
+            return;
+        }
+        const hasStageModerator = channelPermissions.has(
+            PermissionsBitField.StageModerator,
+        );
+        if (!hasStageModerator && isGuildStayEnabled) {
+            await guild.settings.set('stay.enabled', false);
+        }
+        if (!hasStageModerator) {
+            await player.sendMessage(
+                guild.locale(
+                    'MUSIC.SESSION_ENDED.FORCED.STAGE_NOT_MODERATOR',
+                ),
+                { type: MessageOptionsBuilderType.Warning },
+            );
+            await player.disconnect();
+            return;
+        }
+        // To avoid errors from recreating a stage instance, only create one if it doesn't already exist
+        if (newChannel && !newChannel.stageInstance) {
+            try {
+                await newChannel.createStageInstance({
+                    topic: guild.locale('MISC.STAGE_TOPIC'),
+                    privacyLevel: StageInstancePrivacyLevel.GuildOnly,
+                });
+            } catch (error) {
+                if (error instanceof Error) {
+                    logger.error(`${error.message}\n${error.stack}`);
+                }
+            }
+        }
+        // To prevent a regression bug in which Quaver remains silent in stage channels, unsuppress Quaver after stage instance creation
+        // Also handles unsuppressing Quaver mid-track as suppress state updates were intentionally written not to be ignored by Quaver
+        await newState.setSuppressed(false);
+        await onChannelJoinOrMove(
+            guild.client.io,
+            player,
+            newState,
+            isGuildStayEnabled,
+            isOldQuaverStateUpdate,
+        );
+    }
+}
+
+async function handleUserVoiceStateUpdate(
+    oldState: VoiceState,
+    newState: VoiceState,
+    guild: QuaverGuild<Initialized> & Guild,
+    player: QuaverPlayer,
+    isGuildStayEnabled: boolean | unknown,
+    isOldQuaverStateUpdate: boolean,
+): Promise<void> {
+    const newChannelId = newState.channelId;
+    const oldChannelId = oldState.channelId;
+
+    // Since a user joined Quaver's channel while the session was paused, resume the session
+    if (
+        newChannelId === player.voice.channelId &&
+        (player.timeout.pause || player.timeout.pausedAlone)
+    ) {
+        await resumeChannelSession(guild.client.io, player);
+        return;
+    }
+
+    const isUserLeaveOrMoveState = oldChannelId === player.voice.channelId;
+    const pauseAlone =
+        (await guild.settings.get<boolean>('pausealone247')) ?? false;
+    // Since the last user left or moved out from Quaver's channel, handle the empty channel
+    if (
+        isUserLeaveOrMoveState &&
+        oldState.channel?.members.filter(isUser).size < 1 &&
+        (!isGuildStayEnabled || pauseAlone)
+    ) {
+        await onChannelEmpty(
+            guild.client.io,
+            player,
+            isOldQuaverStateUpdate,
+            isGuildStayEnabled,
+        );
+    }
 }
 
 export default new EventHandler()
@@ -182,11 +375,8 @@ export default new EventHandler()
                 hasVoluntaryStateUpdates);
         // Since Quaver is expected to continue playback despite its own state updates, do not operate
         // Handles ignoring state updates from self-deafening or unsuppressing itself from starting tracks
-        if (isOldQuaverStateUpdate && hasSameChannelStateUpdates) {
-            return;
-        }
         // To prevent Quaver from falling through statements doing nothing from a user's state updates, do not operate
-        if (!isOldQuaverStateUpdate && hasSameChannelStateUpdates) {
+        if (hasSameChannelStateUpdates) {
             return;
         }
         const guild = await QuaverGuild.wrap(oldState.guild);
@@ -198,142 +388,37 @@ export default new EventHandler()
         const isGuildStayEnabled =
             await guild.settings.get<boolean>('stay.enabled');
         const hasQuaverDisconnected = isOldQuaverStateUpdate && !newChannelId;
-        // To ensure Quaver does not persist in an inactive session, disable stay feature for this guild
-        if (hasQuaverDisconnected && isGuildStayEnabled) {
-            await guild.settings.set('stay.enabled', false);
-        }
-        // To reset states, properly handle disconnection
-        if (hasQuaverDisconnected && !player.voice.channelId) {
-            logger.info(`[G ${guild.id}] Cleaning up (disconnected)`);
-            await player.sendMessage(
-                guild.locale('MUSIC.SESSION_ENDED.FORCED.DISCONNECTED'),
-                { type: MessageOptionsBuilderType.Warning },
+        
+        if (hasQuaverDisconnected) {
+            await handleQuaverDisconnection(
+                guild,
+                player,
+                oldChannelId,
+                isGuildStayEnabled,
             );
-            await player.disconnect(oldChannelId);
             return;
         }
-        // To help Quaver remain unsuppressed in stage channels, explicitly use booleans for Quaver's state update and newState#channelId
+
         const isQuaverJoinOrMoveState = isOldQuaverStateUpdate && newChannelId;
-        const newChannel = newState.channel;
-        // In this context newState#channel can be null because of leave states, so optional chaining is necessary
-        const newChannelType = newChannel?.type;
-        // To keep the dashboard updated with the latest session details, emit channel events for this guild
         if (isQuaverJoinOrMoveState) {
-            guild.sendWebUpdate('textChannelUpdate', player.queue.channel.name);
-            guild.sendWebUpdate('channelUpdate', newChannel?.name);
+            await handleQuaverJoinOrMove(
+                guild,
+                player,
+                newState,
+                isGuildStayEnabled,
+                isOldQuaverStateUpdate,
+                oldClientUserId,
+            );
+            return;
         }
-        // For type consistency, create an empty map for unhandled states
-        const channelPermissions = isQuaverJoinOrMoveState
-            ? guild.channels.cache
-                  .get(newChannelId)
-                  .permissionsFor(oldClientUserId)
-            : new Map();
-        const hasBasicChannelPermissions = channelPermissions.has(
-            new PermissionsBitField([
-                PermissionsBitField.Flags.ViewChannel,
-                PermissionsBitField.Flags.Connect,
-                PermissionsBitField.Flags.Speak,
-            ]),
+
+        await handleUserVoiceStateUpdate(
+            oldState,
+            newState,
+            guild,
+            player,
+            isGuildStayEnabled,
+            isOldQuaverStateUpdate,
         );
-        if (
-            isQuaverJoinOrMoveState &&
-            newChannelType === ChannelType.GuildVoice
-        ) {
-            // To prevent permission errors, properly disconnect Quaver
-            if (!hasBasicChannelPermissions) {
-                await player.sendMessage(
-                    guild.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC'),
-                    { type: MessageOptionsBuilderType.Error },
-                );
-                await player.disconnect();
-                return;
-            }
-            await onChannelJoinOrMove(
-                guild.client.io,
-                player,
-                newState,
-                isGuildStayEnabled,
-                isOldQuaverStateUpdate,
-            );
-            return;
-        }
-        if (
-            isQuaverJoinOrMoveState &&
-            newChannelType === ChannelType.GuildStageVoice &&
-            isNewSuppress
-        ) {
-            // To prevent permission errors, properly disconnect Quaver
-            if (!hasBasicChannelPermissions) {
-                await player.sendMessage(
-                    guild.locale('DISCORD.INSUFFICIENT_PERMISSIONS.BOT.BASIC'),
-                    { type: MessageOptionsBuilderType.Error },
-                );
-                await player.disconnect();
-                return;
-            }
-            const hasStageModerator = channelPermissions.has(
-                PermissionsBitField.StageModerator,
-            );
-            if (!hasStageModerator && isGuildStayEnabled) {
-                await guild.settings.set('stay.enabled', false);
-            }
-            if (!hasStageModerator) {
-                await player.sendMessage(
-                    guild.locale(
-                        'MUSIC.SESSION_ENDED.FORCED.STAGE_NOT_MODERATOR',
-                    ),
-                    { type: MessageOptionsBuilderType.Warning },
-                );
-                await player.disconnect();
-                return;
-            }
-            // To avoid errors from recreating a stage instance, only create one if it doesn't already exist
-            if (!newChannel.stageInstance) {
-                try {
-                    await newChannel.createStageInstance({
-                        topic: guild.locale('MISC.STAGE_TOPIC'),
-                        privacyLevel: StageInstancePrivacyLevel.GuildOnly,
-                    });
-                } catch (error) {
-                    if (error instanceof Error) {
-                        logger.error(`${error.message}\n${error.stack}`);
-                    }
-                }
-            }
-            // To prevent a regression bug in which Quaver remains silent in stage channels, unsuppress Quaver after stage instance creation
-            // Also handles unsuppressing Quaver mid-track as suppress state updates were intentionally written not to be ignored by Quaver
-            await newState.setSuppressed(false);
-            await onChannelJoinOrMove(
-                guild.client.io,
-                player,
-                newState,
-                isGuildStayEnabled,
-                isOldQuaverStateUpdate,
-            );
-            return;
-        }
-        // Since a user joined Quaver's channel while the session was paused, resume the session
-        if (
-            !isOldQuaverStateUpdate &&
-            newChannelId === player.voice.channelId &&
-            player.timeout.pause
-        ) {
-            await resumeChannelSession(guild.client.io, player);
-            return;
-        }
-        const isUserLeaveOrMoveState =
-            !isOldQuaverStateUpdate && oldChannelId === player.voice.channelId;
-        // Since the last user left or moved out from Quaver's channel and the guild's stay feature is disabled, handle the empty channel
-        if (
-            isUserLeaveOrMoveState &&
-            oldState.channel?.members.filter(isUser).size < 1 &&
-            !isGuildStayEnabled
-        ) {
-            await onChannelEmpty(
-                guild.client.io,
-                player,
-                isOldQuaverStateUpdate,
-                isGuildStayEnabled,
-            );
-        }
     });
+

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -77,6 +77,7 @@ async function resumeChannelSession(
     await player.resume();
     clearTimeout(player.timeout.pause);
     player.timeout.pause = null;
+    player.timeout.pausedAlone = false;
     guild.sendWebUpdate('pauseUpdate', player.paused);
     guild.sendWebUpdate('pauseTimeoutUpdate', !!player.timeout.pause);
     await player.sendMessage(guild.locale('MUSIC.DISCONNECT.ALONE.RESUMING'), {
@@ -99,6 +100,9 @@ async function onChannelEmpty(
         await guild.settings.set('stay.enabled', false);
     }
     if (isPlayerIdle && player.voice.channelId) {
+        if (isGuildStayEnabled) {
+            return;
+        }
         logger.info(`[G ${guild.id}] Disconnecting (alone)`);
         await player.sendMessage(
             guild.locale(
@@ -115,8 +119,29 @@ async function onChannelEmpty(
     if (
         player.timeout.standard ||
         player.timeout.pause ||
+        player.timeout.pausedAlone ||
         !player.voice.channelId
     ) {
+        return;
+    }
+    if (isGuildStayEnabled) {
+        if (player.paused) {
+            return;
+        }
+        await player.pause();
+        guild.sendWebUpdate('pauseUpdate', player.paused);
+        player.timeout.pausedAlone = true;
+        await player.sendMessage(
+            new ContainerBuilder().addTextDisplayComponents(
+                guild.builders.textDisplayLocale(
+                    'MUSIC.DISCONNECT.ALONE.WARNING',
+                ),
+                guild.builders.textDisplayLocale(
+                    'MUSIC.DISCONNECT.ALONE.REJOIN_TO_RESUME',
+                ),
+            ),
+            { type: MessageOptionsBuilderType.Warning },
+        );
         return;
     }
     await pauseChannelSession(io, player);
@@ -136,11 +161,13 @@ async function onChannelJoinOrMove(
     }
     // In this context newState#channel is always defined for join/move states, so optional chaining is unnecessary
     const hasNewChannelUsers = newState.channel.members.filter(isUser).size > 0;
-    if (hasNewChannelUsers && player.timeout.pause) {
+    if (hasNewChannelUsers && (player.timeout.pause || player.timeout.pausedAlone)) {
         await resumeChannelSession(io, player);
     }
     // To prevent Quaver from handling a channel that still has users or the guild's stay feature is enabled, do not handle the channel
-    if (hasNewChannelUsers || isGuildStayEnabled) {
+    const pauseAlone =
+        (await guild.settings.get<boolean>('pausealone247')) ?? false;
+    if (hasNewChannelUsers || (isGuildStayEnabled && !pauseAlone)) {
         return;
     }
     await onChannelEmpty(
@@ -316,18 +343,20 @@ export default new EventHandler()
         if (
             !isOldQuaverStateUpdate &&
             newChannelId === player.voice.channelId &&
-            player.timeout.pause
+            (player.timeout.pause || player.timeout.pausedAlone)
         ) {
             await resumeChannelSession(guild.client.io, player);
             return;
         }
         const isUserLeaveOrMoveState =
             !isOldQuaverStateUpdate && oldChannelId === player.voice.channelId;
-        // Since the last user left or moved out from Quaver's channel and the guild's stay feature is disabled, handle the empty channel
+        const pauseAlone =
+            (await guild.settings.get<boolean>('pausealone247')) ?? false;
+        // Since the last user left or moved out from Quaver's channel, handle the empty channel
         if (
             isUserLeaveOrMoveState &&
             oldState.channel?.members.filter(isUser).size < 1 &&
-            !isGuildStayEnabled
+            (!isGuildStayEnabled || pauseAlone)
         ) {
             await onChannelEmpty(
                 guild.client.io,

--- a/src/lib/data/DataHandler.ts
+++ b/src/lib/data/DataHandler.ts
@@ -11,6 +11,7 @@ type DatabaseObject = {
 type GuildSettingsObject = {
     stay?: StaySettingObject;
     locale?: string;
+    pausealone247?: boolean;
 };
 
 type StaySettingObject = {

--- a/src/lib/music/QuaverPlayer.ts
+++ b/src/lib/music/QuaverPlayer.ts
@@ -106,6 +106,7 @@ export class QuaverPlayer<TNode extends Node = Node> extends Player<TNode> {
         standard?: ReturnType<typeof setTimeout>;
         pause?: ReturnType<typeof setTimeout>;
         end?: number;
+        pausedAlone?: boolean;
     } = {};
     // overriding native queue type
     queue: QuaverQueue;
@@ -391,6 +392,7 @@ export class QuaverPlayer<TNode extends Node = Node> extends Player<TNode> {
         }
         clearTimeout(this.timeout.standard);
         clearTimeout(this.timeout.pause);
+        this.timeout.pausedAlone = false;
         this.voice.disconnect();
         await this.client.music.players.destroy(guild.id);
         guild.sendWebUpdate('playerDisconnect');
@@ -521,6 +523,7 @@ export class QuaverPlayer<TNode extends Node = Node> extends Player<TNode> {
             await this.pause();
         } else {
             await this.resume();
+            this.timeout.pausedAlone = false;
             if (!this.playing && this.queue.tracks.length > 0) {
                 await this.queue.start();
             }

--- a/src/lib/settings/PlaybackLogicHandler.ts
+++ b/src/lib/settings/PlaybackLogicHandler.ts
@@ -37,6 +37,19 @@ export class PlaybackLogicHandler {
                 );
                 return;
             }
+            case 'pausealone247': {
+                const pauseAlone =
+                    (await guild.settings.get<boolean>('pausealone247')) ?? false;
+                await guild.settings.set('pausealone247', !pauseAlone);
+                await interaction.replyHandler.reply(
+                    await SettingsRenderer.renderSubMenu(
+                        await QuaverGuild.wrap(interaction.guild),
+                        SettingsCategory.Playback,
+                    ),
+                    { force: ForceType.Update },
+                );
+                return;
+            }
             case 'source': {
                 const source =
                     (await guild.settings.get<string>('source')) ??

--- a/src/lib/settings/SettingsRenderer.ts
+++ b/src/lib/settings/SettingsRenderer.ts
@@ -201,6 +201,8 @@ export class SettingsRenderer {
     ): Promise<SectionBuilder[]> {
         const notify =
             (await guild.settings.get<boolean>('notifyin247')) ?? true;
+        const pauseAlone =
+            (await guild.settings.get<boolean>('pausealone247')) ?? false;
         const source =
             (await guild.settings.get<string>('source')) ??
             Object.keys(acceptableSources)[0];
@@ -217,6 +219,15 @@ export class SettingsRenderer {
                               notify ? 'MISC.ENABLED' : 'MISC.DISABLED',
                           ),
                           notify ? ButtonStyle.Success : ButtonStyle.Danger,
+                      ),
+                      this.createItemSection(
+                          guild,
+                          SettingsCategory.Playback,
+                          'pausealone247',
+                          guild.locale(
+                              pauseAlone ? 'MISC.ENABLED' : 'MISC.DISABLED',
+                          ),
+                          pauseAlone ? ButtonStyle.Success : ButtonStyle.Danger,
                       ),
                   ]
                 : []),

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -33,7 +33,7 @@ export const settingsOptions = [
         ? ['premium']
         : []),
     'language',
-    ...(settings.features.stay.enabled ? ['notifyin247'] : []),
+    ...(settings.features.stay.enabled ? ['notifyin247', 'pausealone247'] : []),
     'format',
     'dj',
     'source',

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -40,6 +40,7 @@ export type SettingsPageOptions =
     | 'premium'
     | 'language'
     | 'notifyin247'
+    | 'pausealone247'
     | 'format'
     | 'dj'
     | 'source'


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZPTXDev/Quaver/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (left side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [x] Is your code documented, if applicable? (Check if not applicable)
- [x] Does this PR have a linked issue?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Other

### Priority
- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low

### Description
Please describe the changes.
Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Pause alone (24/7)" option to playback settings with a toggle in the playback menu.
  * Added localized label and description for the new option.

* **Behavior Changes / Bug Fixes**
  * Bot now properly pauses/resumes and sends pause warnings when left alone, respecting the guild's 24/7 ("stay") and pause-alone setting.
  * Improved join/move handling so sessions resume correctly after pause states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZPTXDev/Quaver/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->